### PR TITLE
Add "json-server" to test the application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 /cache
+/config/*
+!/config/json-server.json
+!/config/api-skeleton.json
 /public
 /node_modules
 db.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /cache
 /public
 /node_modules
+db.json
 docker-compose.yml
 package-lock.json
 yarn.lock

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This is a basic application skeleton to easily bootstrap a web application. Ther
 
 You need to have `node` 6+ and `npm` 5+ installed on your computer, but it is recommended to use `yarn` to manage your dependencies.
 
+### Build the application
+
 First install the dependencies:
 
 ```bash
@@ -23,7 +25,8 @@ $ yarn install
 # or
 $ npm install
 ```
-Then run the test server:
+
+Then run the test server, which will open the application in your default browser (at `localhost:9000`):
 
 ```bash
 $ yarn serve
@@ -31,12 +34,40 @@ $ yarn serve
 $ npm run serve
 ```
 
-You can build the files for production environments by running:
+If you want to run the application through a web server like `Apache` or `nginx`, you can build it for production by running:
 
 ```bash
 $ yarn build:prod
 # or
 $ npm run build:prod
+```
+
+or for development (non minimized Javascript and CSS files) by running:
+
+```bash
+$ yarn build:dev
+# or
+$ npm run build:dev
+```
+
+### Configure the API access
+
+This application is made to consume an API. You can either use a real API or use the `json-server` library.
+
+- **With a real API**
+
+First, clone the [`symfony-api`](https://github.com/damien-carcel/app-skeleton/tree/symfony-api) branch from this repository and follow its installation instructions.
+
+Then copy the configuration file `config/api-skeleton.json` into `configuration/api.json`. This configuration is made accordingly to the `symfony-api` branch default configuration.
+
+- **With the `json-server` library**
+
+Copy the configuration file `config/json-server.json` into `configuration/api.json`, then run the JSON server:
+
+```bash
+$ yarn serve-api
+# or
+$ npm run serve-api
 ```
 
 ## License

--- a/config/api-skeleton.json
+++ b/config/api-skeleton.json
@@ -1,0 +1,15 @@
+{
+  "api_config": {
+    "protocol": "http",
+    "host": "localhost",
+    "port": 8080,
+    "prefix": "/rest/blog",
+    "routes": {
+      "list": "/posts",
+      "get": "/post/{id}",
+      "create": "/post/create",
+      "update": "/post/{id}/update",
+      "delete": "/post/{id}/delete"
+    }
+  }
+}

--- a/config/json-server.json
+++ b/config/json-server.json
@@ -1,0 +1,15 @@
+{
+  "api_config": {
+    "protocol": "http",
+    "host": "localhost",
+    "port": 3000,
+    "prefix": "",
+    "routes": {
+      "list": "/posts",
+      "get": "/posts/{id}",
+      "create": "/posts",
+      "update": "/posts/{id}",
+      "delete": "/posts/{id}"
+    }
+  }
+}

--- a/db.json.dist
+++ b/db.json.dist
@@ -1,0 +1,19 @@
+{
+  "posts": [
+    {
+      "title": "A first post",
+      "content": "A very uninteresting content.",
+      "id": "XIa_H8p"
+    },
+    {
+      "title": "Another post",
+      "content": "Bla bla bla bla bla bla.",
+      "id": "_D4pvBw"
+    },
+    {
+      "title": "And yet another",
+      "content": "Still nothing interesting.",
+      "id": "FeZwhwE"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "build:dev": "webpack --env=dev --progress",
     "lint": "node ./node_modules/eslint/bin/eslint 'src/**/*.js'",
     "lint-fix": "node ./node_modules/eslint/bin/eslint 'src/**/*.js' --fix",
-    "serve": "webpack-dev-server --env=dev --open"
+    "serve": "webpack-dev-server --env=dev --open",
+    "serve-api": "json-server --watch db.json --routes routes.json"
   },
   "dependencies": {
     "prop-types": "^15.6.0",
@@ -49,6 +50,7 @@
     "file-loader": "^1.1.4",
     "html-webpack-plugin": "^2.30.1",
     "html-webpack-template": "^5.6.0",
+    "json-server": "^0.12.1",
     "less": "^2.7.2",
     "less-loader": "^4.0.5",
     "style-loader": "^0.18.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint": "node ./node_modules/eslint/bin/eslint 'src/**/*.js'",
     "lint-fix": "node ./node_modules/eslint/bin/eslint 'src/**/*.js' --fix",
     "serve": "webpack-dev-server --env=dev --open",
-    "serve-api": "json-server --watch db.json --routes routes.json"
+    "serve-api": "json-server --watch db.json"
   },
   "dependencies": {
     "prop-types": "^15.6.0",

--- a/routes.json
+++ b/routes.json
@@ -1,7 +1,0 @@
-{
-  "/rest/blog/post/create": "/posts",
-  "/rest/blog/posts": "/posts",
-  "/rest/blog/post/:id": "/posts/:id",
-  "/rest/blog/post/:id/update": "/posts/:id",
-  "/rest/blog/post/:id/delete": "/posts/:id"
-}

--- a/routes.json
+++ b/routes.json
@@ -1,0 +1,7 @@
+{
+  "/rest/blog/post/create": "/posts",
+  "/rest/blog/posts": "/posts",
+  "/rest/blog/post/:id": "/posts/:id",
+  "/rest/blog/post/:id/update": "/posts/:id",
+  "/rest/blog/post/:id/delete": "/posts/:id"
+}

--- a/src/containers/posts.js
+++ b/src/containers/posts.js
@@ -1,5 +1,8 @@
+import config from '../../config/api.json';
+
 export function listPosts() {
-  const url = 'http://localhost:8001/rest/blog/posts';
+  const route = config.api_config.routes.list;
+  const url = getApiUrl(route);
 
   return fetch(url, {
       headers: createHeaders(),
@@ -8,7 +11,8 @@ export function listPosts() {
 }
 
 export function getPost(postId) {
-  const url = 'http://localhost:8001/rest/blog/post/' + postId;
+  const route = config.api_config.routes.get;
+  const url = getApiUrl(route, postId);
 
   return fetch(url, {
     headers: createHeaders(),
@@ -17,7 +21,8 @@ export function getPost(postId) {
 }
 
 export function deletePost(postId) {
-  const url = 'http://localhost:8001/rest/blog/post/' + postId + '/delete';
+  const route = config.api_config.routes.delete;
+  const url = getApiUrl(route, postId);
 
   return fetch(url, {
     headers: createHeaders(),
@@ -26,7 +31,8 @@ export function deletePost(postId) {
 }
 
 export function createPost(data) {
-  const url = 'http://localhost:8001/rest/blog/post/create';
+  const route = config.api_config.routes.create;
+  const url = getApiUrl(route);
 
   return fetch(url, {
     body: JSON.stringify(data),
@@ -36,13 +42,29 @@ export function createPost(data) {
 }
 
 export function updatePost(postId, data) {
-  const url = 'http://localhost:8001/rest/blog/post/' + postId + '/update';
+  const route = config.api_config.routes.update;
+  const url = getApiUrl(route, postId);
 
   return fetch(url, {
     body: JSON.stringify(data),
     headers: createHeaders(),
     method: 'PATCH'
   }).then(response => response.json());
+}
+
+function getApiUrl(route, postId = null) {
+  const protocol = config.api_config.protocol;
+  const host = config.api_config.host;
+  const port = config.api_config.port;
+  const prefix = config.api_config.prefix;
+
+  const baseUrl = protocol + '://' + host + ':' + port + prefix;
+
+  if (null !== postId) {
+    return baseUrl + route.replace('{id}', postId);
+  }
+
+  return baseUrl + route;
 }
 
 function createHeaders() {

--- a/src/containers/posts.js
+++ b/src/containers/posts.js
@@ -1,7 +1,10 @@
 export function listPosts() {
   const url = 'http://localhost:8001/rest/blog/posts';
 
-  return fetch(url).then(response => response.json());
+  return fetch(url, {
+      headers: createHeaders(),
+      method: 'GET'
+  }).then(response => response.json());
 }
 
 export function getPost(postId) {
@@ -38,7 +41,7 @@ export function updatePost(postId, data) {
   return fetch(url, {
     body: JSON.stringify(data),
     headers: createHeaders(),
-    method: 'POST'
+    method: 'PATCH'
   }).then(response => response.json());
 }
 


### PR DESCRIPTION
This PR adds the `json-server` library, and makes the API calls fully configurable:
- configure the host and port of the API, and the different used routes in a file `config/api.json`,
- this allows to switch from a real API to the `json-server` just by changing this configuration file.

Both way are fully documented in the README.