### PR TITLE
Issue 74: Use only autowiring and service aliases

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -30,7 +30,7 @@ acceptance:
             contexts:
                 - App\Tests\Acceptance\Context\FeatureContext: ~
                 - App\Tests\Acceptance\Context\FixtureContext:
-                    inMemoryBlogPostRepository: '@app.repository.blog_post'
+                    inMemoryBlogPostRepository: '@App\Repository\BlogPostRepositoryInterface'
 
 system:
     extensions:

--- a/config/packages/acceptance/services.yaml
+++ b/config/packages/acceptance/services.yaml
@@ -2,8 +2,7 @@ services:
     _defaults:
         autowire: true
         autoconfigure: true
-        public: false
-
-    app.repository.blog_post:
-        class: 'App\Repository\InMemory\BlogPostRepository'
         public: true
+
+    App\Repository\InMemory\BlogPostRepository:
+    App\Repository\BlogPostRepositoryInterface: '@App\Repository\InMemory\BlogPostRepository'

--- a/config/packages/dev/services.yaml
+++ b/config/packages/dev/services.yaml
@@ -4,5 +4,5 @@ services:
         autoconfigure: true
         public: false
 
-    app.repository.blog_post:
-        class: 'App\Repository\Doctrine\BlogPostRepository'
+    App\Repository\Doctrine\BlogPostRepository: ~
+    App\Repository\BlogPostRepositoryInterface: '@App\Repository\Doctrine\BlogPostRepository'

--- a/config/packages/prod/services.yaml
+++ b/config/packages/prod/services.yaml
@@ -4,5 +4,5 @@ services:
         autoconfigure: true
         public: false
 
-    app.repository.blog_post:
-        class: 'App\Repository\Doctrine\BlogPostRepository'
+    App\Repository\Doctrine\BlogPostRepository: ~
+    App\Repository\BlogPostRepositoryInterface: '@App\Repository\Doctrine\BlogPostRepository'

--- a/config/packages/test/services.yaml
+++ b/config/packages/test/services.yaml
@@ -4,5 +4,5 @@ services:
         autoconfigure: true
         public: false
 
-    app.repository.blog_post:
-        class: 'App\Repository\Doctrine\BlogPostRepository'
+    App\Repository\Doctrine\BlogPostRepository: ~
+    App\Repository\BlogPostRepositoryInterface: '@App\Repository\Doctrine\BlogPostRepository'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -26,9 +26,3 @@ services:
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
-    App\Controller\IndexController:
-        public: true
-        autowire: false
-        arguments:
-            - '@app.repository.blog_post'
-            - '@twig'

--- a/src/Repository/InMemory/BlogPostRepository.php
+++ b/src/Repository/InMemory/BlogPostRepository.php
@@ -29,14 +29,14 @@ class BlogPostRepository implements BlogPostRepositoryInterface
      */
     public function getAllBlogPosts(): array
     {
-        return $this->blogPosts;
+        return array_values($this->blogPosts);
     }
 
     /**
-     * @param BlogPost $blogPost
+     * @param BlogPost $post
      */
-    public function addBlogPost(BlogPost $blogPost): void
+    public function save(BlogPost $post): void
     {
-        $this->blogPosts[] = $blogPost;
+        $this->blogPosts[$post->id()->toString()] = $post;
     }
 }

--- a/tests/acceptance/Context/FeatureContext.php
+++ b/tests/acceptance/Context/FeatureContext.php
@@ -42,9 +42,9 @@ class FeatureContext implements KernelAwareContext
      *
      * @throws \Exception
      *
-     * @When a demo scenario sends a request to :path
+     * @When a request is sent to :path
      */
-    public function aDemoScenarioSendsARequestTo(string $path): void
+    public function aRequestIsSentTo(string $path): void
     {
         $this->response = $this->kernel->handle(Request::create($path, 'GET'));
     }
@@ -54,7 +54,7 @@ class FeatureContext implements KernelAwareContext
      *
      * @Then a response should be received
      */
-    public function theResponseShouldBeReceived(): void
+    public function aResponseShouldBeReceived(): void
     {
         if ($this->response === null) {
             throw new \RuntimeException('No response received');

--- a/tests/acceptance/Context/FixtureContext.php
+++ b/tests/acceptance/Context/FixtureContext.php
@@ -48,7 +48,7 @@ class FixtureContext implements Context
             $postEntity = new BlogPost();
             $postEntity->update($post);
 
-            $this->inMemoryBlogPostRepository->addBlogPost($postEntity);
+            $this->inMemoryBlogPostRepository->save($postEntity);
         }
     }
 }

--- a/tests/acceptance/features/demo.feature
+++ b/tests/acceptance/features/demo.feature
@@ -9,5 +9,5 @@ Feature:
 
   @system
   Scenario: It receives a response from Symfony's kernel
-    When a demo scenario sends a request to "/"
+    When a request is sent to "/"
     Then a response should be received

--- a/tests/system/Context/FeatureContext.php
+++ b/tests/system/Context/FeatureContext.php
@@ -39,9 +39,9 @@ class FeatureContext extends MinkContext implements KernelAwareContext
      *
      * @throws \Exception
      *
-     * @When a demo scenario sends a request to :path
+     * @When a request is sent to :path
      */
-    public function aDemoScenarioSendsARequestTo(string $path): void
+    public function aRequestIsSentTo(string $path): void
     {
         $this->visitPath($path);
     }
@@ -51,7 +51,7 @@ class FeatureContext extends MinkContext implements KernelAwareContext
      *
      * @Then a response should be received
      */
-    public function theResponseShouldBeReceived(): void
+    public function aResponseShouldBeReceived(): void
     {
         $this->assertResponseContains('');
     }


### PR DESCRIPTION
This PR removes the declaration of the `BlogPost` repositories as service to only use autowiring.

The repository is replaced in the `acceptance` tests thanks to service aliases.