### PR TITLE
Issue 81: Bring back last missing functionalities for Webpack 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+node_js:
+    - '8'
+    - '9'
+
+install:
+    - yarn install
+
+script:
+    - yarn lint

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "copy-webpack-plugin": "^4.5.1",
     "css-loader": "^0.28.11",
     "eslint": "^4.19.1",
+    "extract-text-webpack-plugin": "^4.0.0-beta.0",
     "file-loader": "^1.1.11",
     "html-webpack-plugin": "^3.1.0",
     "html-webpack-template": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:dev": "webpack --mode development --progress",
     "lint": "node ./node_modules/eslint/bin/eslint 'src/**/*.js'",
     "lint-fix": "node ./node_modules/eslint/bin/eslint 'src/**/*.js' --fix",
-    "serve": "webpack-dev-server --mode development --open"
+    "serve": "webpack-dev-server --mode development --open --hot --inline"
   },
   "dependencies": {},
   "devDependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const ExtractTextPlugin = require("extract-text-webpack-plugin");
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const WebappWebpackPlugin = require('webapp-webpack-plugin');
 
@@ -15,6 +16,7 @@ module.exports = (env, argv) => ({
     }
   },
   output: {
+    filename: argv.mode === 'development' ? '[name].js' : '[name].[chunkhash].js',
     path: path.resolve(__dirname, 'public')
   },
   module: {
@@ -40,11 +42,23 @@ module.exports = (env, argv) => ({
       },
       {
         test: /\.less$/,
-        use: ['style-loader', 'css-loader', 'less-loader']
+        use: ExtractTextPlugin.extract({
+          use: [{
+            loader: "css-loader"
+          }, {
+            loader: "less-loader"
+          }],
+          fallback: "style-loader"
+        })
       },
       {
         test: /\.css$/,
-        use: ['style-loader', 'css-loader']
+        use: ExtractTextPlugin.extract({
+          use: [{
+            loader: "css-loader"
+          }],
+          fallback: "style-loader"
+        })
       }
     ]
   },
@@ -54,15 +68,17 @@ module.exports = (env, argv) => ({
       {from: './assets/files/humans.txt'},
       {from: './assets/files/robots.txt'}
     ]),
+    new ExtractTextPlugin({
+      filename: "[name].[chunkhash].css",
+      disable: argv.mode === 'development'
+    }),
     new HtmlWebpackPlugin({
       inject: false,
       lang: 'en',
-      meta: [
-        {
-          name: 'description',
-          content: 'A basic skeleton for ES6 web applications'
-        }
-      ],
+      meta: [{
+        name: 'description',
+        content: 'A basic skeleton for ES6 web applications'
+      }],
       mobile: true,
       minify: {
         removeComments: argv.mode === 'production',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,6 @@
 /* eslint-env amd, node */
 
 const path = require('path');
-const webpack = require('webpack');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
@@ -11,7 +10,9 @@ module.exports = (env, argv) => ({
   devServer: {
     contentBase: path.join(__dirname, 'public'),
     port: 9000,
-    hot: true
+    stats: {
+      colors: true
+    }
   },
   output: {
     path: path.resolve(__dirname, 'public')
@@ -31,15 +32,11 @@ module.exports = (env, argv) => ({
       },
       {
         test: /\.(gif|jpg|png|svg)$/,
-        use: [
-          'file-loader'
-        ]
+        use: ['file-loader']
       },
       {
         test: /\.(eot|otf|ttf|woff|woff2)$/,
-        use: [
-          'file-loader'
-        ]
+        use: ['file-loader']
       },
       {
         test: /\.less$/,
@@ -54,8 +51,8 @@ module.exports = (env, argv) => ({
   plugins: [
     new CleanWebpackPlugin(['public']),
     new CopyWebpackPlugin([
-      { from: './assets/files/humans.txt' },
-      { from: './assets/files/robots.txt' }
+      {from: './assets/files/humans.txt'},
+      {from: './assets/files/robots.txt'}
     ]),
     new HtmlWebpackPlugin({
       inject: false,
@@ -74,7 +71,6 @@ module.exports = (env, argv) => ({
       template: './src/templates/index.ejs',
       title: 'My ES6 application skeleton'
     }),
-    new webpack.HotModuleReplacementPlugin(),
     new WebappWebpackPlugin({
       logo: './assets/images/pingoo.png',
       inject: true,


### PR DESCRIPTION
Relates to #81.

This PR adds back the extraction of CSS and the use of hashed names for caching, both in production mode only.

It also cleans the way HMR is done (no more configuration, only `webpack-dev-server` command line options).