### PR TITLE
Issue 103: Add phpspec templates

### DIFF
--- a/back/.phpspec/class.tpl
+++ b/back/.phpspec/class.tpl
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of AppSkeleton.
+ *
+ * Copyright (c) 2018 Damien Carcel <damien.carcel@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace %namespace%;
+
+/**
+ * @author Damien Carcel <damien.carcel@gmail.com>
+ */
+class %name%
+{
+}

--- a/back/.phpspec/specification.tpl
+++ b/back/.phpspec/specification.tpl
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of AppSkeleton.
+ *
+ * Copyright (c) 2018 Damien Carcel <damien.carcel@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace %namespace%;
+
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @author Damien Carcel <damien.carcel@gmail.com>
+ */
+class %name% extends ObjectBehavior
+{
+}

--- a/back/tests/spec/Entity/BlogPostSpec.php
+++ b/back/tests/spec/Entity/BlogPostSpec.php
@@ -1,12 +1,32 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of AppSkeleton.
+ *
+ * Copyright (c) 2018 Damien Carcel <damien.carcel@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace spec\App\Entity;
 
+use App\Entity\BlogPost;
 use PhpSpec\ObjectBehavior;
 use Ramsey\Uuid\Uuid;
 
+/**
+ * @author Damien Carcel <damien.carcel@gmail.com>
+ */
 class BlogPostSpec extends ObjectBehavior
 {
+    function it_is_a_blog_post()
+    {
+        $this->shouldBeAnInstanceOf(BlogPost::class);
+    }
+
     function it_updates_itself()
     {
         $this->update([


### PR DESCRIPTION
Relates to #103.

This PR adds two phpspec templates for generated specifications (using the `phpspec desc` command) and for the classes generated when running specifications.