### PR TITLE
Issue 104: Restart nginx-front after running webpack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ yarn :
 	docker-compose run --rm node yarn install
 
 webpack :
-	docker-compose run --rm node yarn build:dev
+	docker-compose run --rm node yarn build:dev && docker-compose restart nginx-front
 
 composer :
 	docker-compose exec fpm composer update --prefer-dist --optimize-autoloader


### PR DESCRIPTION
Relates to #104.

This allows to avoid a 403 error from Nginx after rebuilding the front app.