### PR TITLE
Issue 113: Add and configure "webpack-image-loader"

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -53,6 +53,7 @@
     "file-loader": "^1.1.11",
     "html-webpack-plugin": "^3.1.0",
     "html-webpack-template": "^6.1.0",
+    "image-webpack-loader": "^4.3.1",
     "json-server": "^0.12.1",
     "less": "^3.0.1",
     "less-loader": "^4.1.0",

--- a/front/webpack.config.js
+++ b/front/webpack.config.js
@@ -37,7 +37,15 @@ module.exports = (env, argv) => ({
       },
       {
         test: /\.(gif|jpg|png|svg)$/,
-        use: ['file-loader']
+        use: [
+          'file-loader',
+          {
+            loader: 'image-webpack-loader',
+            options: {
+              disable: argv.mode === 'development'
+            },
+          }
+        ]
       },
       {
         test: /\.(eot|otf|ttf|woff|woff2)$/,


### PR DESCRIPTION
Relates to #113.
The loader is activated only in production mode.