### PR TITLE
Issue 134: Improve PHP Code Sniffer configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
 script:
     - cd ${TRAVIS_BUILD_DIR}/front && yarn lint
     - cd ${TRAVIS_BUILD_DIR}/front && yarn type-check
-    - cd ${TRAVIS_BUILD_DIR}/back && vendor/bin/phpcs -p --standard=PSR2 --extensions=php src tests/acceptance tests/integration tests/end-to-end
+    - cd ${TRAVIS_BUILD_DIR}/back && vendor/bin/phpcs
     - cd ${TRAVIS_BUILD_DIR}/back && vendor/bin/php-cs-fixer fix --dry-run -v --diff --config=.php_cs.php
     - cd ${TRAVIS_BUILD_DIR}/back && vendor/bin/php-cs-fixer fix --dry-run -v --diff --config=.php_cs.phpspec.php
     - cd ${TRAVIS_BUILD_DIR}/back && vendor/bin/phpspec run

--- a/back/composer.json
+++ b/back/composer.json
@@ -74,7 +74,7 @@
       "@integration",
       "@end-to-end"
     ],
-    "phpcs": "vendor/bin/phpcs -p --standard=PSR2 --extensions=php src tests/acceptance tests/integration tests/end-to-end",
+    "phpcs": "vendor/bin/phpcs",
     "php-cs-fixer": "vendor/bin/php-cs-fixer fix --dry-run -v --diff --config=.php_cs.php && vendor/bin/php-cs-fixer fix -v --dry-run --diff --config=.php_cs.phpspec.php",
     "php-cs-fixer-fix": "vendor/bin/php-cs-fixer fix -v --diff --config=.php_cs.php && vendor/bin/php-cs-fixer fix -v --diff --config=.php_cs.phpspec.php",
     "phpspec": "vendor/bin/phpspec run",

--- a/back/phpcs.xml
+++ b/back/phpcs.xml
@@ -12,8 +12,35 @@
     <arg name="extensions" value="php"/>
     <arg value="np"/>
 
-    <rule ref="PSR2">
-        <exclude-pattern>tests/spec/</exclude-pattern>
+    <rule ref="Generic.Arrays.ArrayIndent"/>
+    <rule ref="Generic.ControlStructures.InlineControlStructure"/>
+    <rule ref="Generic.Debug.ClosureLinter"/>
+    <rule ref="Generic.Debug.ESLint"/>
+    <rule ref="Generic.Files.LineEndings"/>
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="100" />
+            <property name="absoluteLineLimit" value="120" />
+        </properties>
     </rule>
+    <rule ref="Generic.Formatting.MultipleStatementAlignment"/>
+    <rule ref="Generic.Functions.OpeningFunctionBraceBsdAllman"/>
+    <rule ref="Generic.Metrics.CyclomaticComplexity"/>
+    <rule ref="Generic.Metrics.NestingLevel"/>
+    <rule ref="Generic.NamingConventions.CamelCapsFunctionName">
+        <exclude-pattern>*/tests/spec/*</exclude-pattern>
+    </rule>
+    <rule ref="Generic.PHP.ForbiddenFunctions"/>
+    <rule ref="Generic.PHP.NoSilencedErrors"/>
+    <rule ref="Generic.Strings.UnnecessaryStringConcat"/>
+    <rule ref="Generic.WhiteSpace.ArbitraryParenthesesSpacing"/>
+    <rule ref="Generic.WhiteSpace.ScopeIndent"/>
+    <rule ref="PSR2.Classes.ClassDeclaration"/>
+    <rule ref="PSR2.ControlStructures.ControlStructureSpacing"/>
+    <rule ref="PSR2.ControlStructures.SwitchDeclaration"/>
+    <rule ref="PSR2.Methods.FunctionCallSignature">
+        <exclude-pattern>*/tests/spec/*</exclude-pattern>
+    </rule>
+    <rule ref="PSR12.Namespaces.CompoundNamespaceDepth"/>
 
 </ruleset>

--- a/back/phpcs.xml
+++ b/back/phpcs.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<ruleset name="AppSkeleton">
+    <description>This file contains the coding standard followed by the back-end application.</description>
+
+    <file>.php_cs.php</file>
+    <file>.php_cs.phpspec.php</file>
+    <file>src</file>
+    <file>tests</file>
+
+    <arg name="basepath" value="."/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+    <arg value="np"/>
+
+    <rule ref="PSR2">
+        <exclude-pattern>tests/spec/</exclude-pattern>
+    </rule>
+
+</ruleset>

--- a/doc/test/back/local.md
+++ b/doc/test/back/local.md
@@ -17,7 +17,8 @@ For each of them, configuration is already provided and ready to work.
  
 ## PHP code sniffer
 
-`phpcs` checks for coding standard violations. To use it, run the following command:
+`phpcs` checks for coding standard violations. Its configuration is placed in the `phpcs.xml` file.
+To use it, run the following command:
 ```bash
 $ composer phpcs
 ```


### PR DESCRIPTION
## Description

- Use a config file for PHP Code Sniffer
- Customize the rules so it can also be applied to phpspec files

## Definition Of Done

| Q                 | A
| ------------------| ---
| Specifications    | -
| Acceptance tests  | -
| Integration tests | -
| System tests      | -
| Documentation     | OK
| Related tickets   | #134

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
