### PR TITLE
Issue 139: Remove PHP Code Sniffer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ install:
 script:
     - cd ${TRAVIS_BUILD_DIR}/front && yarn lint
     - cd ${TRAVIS_BUILD_DIR}/front && yarn type-check
-    - cd ${TRAVIS_BUILD_DIR}/back && vendor/bin/phpcs
     - cd ${TRAVIS_BUILD_DIR}/back && vendor/bin/php-cs-fixer fix --dry-run -v --diff --config=.php_cs.php
     - cd ${TRAVIS_BUILD_DIR}/back && vendor/bin/php-cs-fixer fix --dry-run -v --diff --config=.php_cs.phpspec.php
     - cd ${TRAVIS_BUILD_DIR}/back && vendor/bin/phpspec run

--- a/back/composer.json
+++ b/back/composer.json
@@ -30,7 +30,6 @@
     "friendsofphp/php-cs-fixer": "^2.12",
     "phpmd/phpmd": "^2.6",
     "phpspec/phpspec": "^4.3",
-    "squizlabs/php_codesniffer": "^3.2",
     "symfony/dotenv": "*",
     "symfony/requirements-checker": "^1.1",
     "symfony/thanks": "^1.0",
@@ -75,14 +74,12 @@
       "@auto-scripts"
     ],
     "tests": [
-      "@phpcs",
       "@php-cs-fixer",
       "@phpspec",
       "@acceptance",
       "@integration",
       "@end-to-end"
     ],
-    "phpcs": "vendor/bin/phpcs",
     "php-cs-fixer": "vendor/bin/php-cs-fixer fix --dry-run -v --diff --config=.php_cs.php && vendor/bin/php-cs-fixer fix -v --dry-run --diff --config=.php_cs.phpspec.php",
     "php-cs-fixer-fix": "vendor/bin/php-cs-fixer fix -v --diff --config=.php_cs.php && vendor/bin/php-cs-fixer fix -v --diff --config=.php_cs.phpspec.php",
     "phpspec": "vendor/bin/phpspec run",

--- a/back/symfony.lock
+++ b/back/symfony.lock
@@ -206,9 +206,6 @@
     "sebastian/recursion-context": {
         "version": "3.0.0"
     },
-    "squizlabs/php_codesniffer": {
-        "version": "3.2.3"
-    },
     "symfony/browser-kit": {
         "version": "v3.4.2"
     },


### PR DESCRIPTION
## Description

`php-cs-fixer` is enough for the CI. The only rule that Code Sniffer was bringing was the max of 120 characters per line.

## Definition Of Done

| Q                 | A
| ------------------| ---
| Specifications    | -
| Acceptance tests  | -
| Integration tests | -
| System tests      | -
| Documentation     | -
| Related tickets   | #139

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
