### PR TITLE
Issue 153: Use dedicated Docker images

### DIFF
--- a/back/.gitignore
+++ b/back/.gitignore
@@ -1,8 +1,4 @@
 /composer.lock
-/docker
-!/docker/nginx.conf
-!/docker/upload.conf
-/public/check.php
 
 ###> symfony/framework-bundle ###
 .env

--- a/back/composer.json
+++ b/back/composer.json
@@ -65,7 +65,8 @@
   "scripts": {
     "auto-scripts": {
       "cache:clear": "symfony-cmd",
-      "assets:install %PUBLIC_DIR%": "symfony-cmd"
+      "assets:install %PUBLIC_DIR%": "symfony-cmd",
+      "requirements-checker": "script"
     },
     "post-install-cmd": [
       "@auto-scripts"

--- a/back/docker-compose.override.yaml.dist
+++ b/back/docker-compose.override.yaml.dist
@@ -4,24 +4,11 @@ services:
     nginx-back:
         ports:
             - '8000:80'
-#        networks:
-#            - 'front_app-skeleton'
 
     php:
-        environment:
-            PHP_XDEBUG_ENABLED: 0
         ports:
             - '8000:8000'
-#        networks:
-#            - 'front_app-skeleton'
 
     mysql:
         ports:
             - '33006:3306'
-#        networks:
-#            - 'front_app-skeleton'
-
-# Use the networks only when front run on Docker too
-# networks:
-#     front_app-skeleton:
-#         external: true

--- a/back/docker-compose.override.yaml.dist
+++ b/back/docker-compose.override.yaml.dist
@@ -4,22 +4,22 @@ services:
     nginx-back:
         ports:
             - '8000:80'
-#         networks:
-#             - 'front_app-skeleton'
+#        networks:
+#            - 'front_app-skeleton'
 
-    fpm:
+    php:
         environment:
-            COMPOSER_CACHE_DIR: '/home/docker/.cache/composer'
-            COMPOSER_HOME: '/home/docker/.config/composer'
             PHP_XDEBUG_ENABLED: 0
-#         networks:
-#             - 'front_app-skeleton'
+        ports:
+            - '8000:8000'
+#        networks:
+#            - 'front_app-skeleton'
 
     mysql:
         ports:
             - '33006:3306'
-#         networks:
-#             - 'front_app-skeleton'
+#        networks:
+#            - 'front_app-skeleton'
 
 # Use the networks only when front run on Docker too
 # networks:

--- a/back/docker-compose.yaml
+++ b/back/docker-compose.yaml
@@ -12,6 +12,7 @@ services:
 
     fpm:
         build: './docker/fpm/'
+        image: 'skeleton/php:7.2-fpm'
         environment:
             APP_ENV: 'prod'
             APP_SECRET: '9a1424cc2734b94f17f8374f97e50a3b'
@@ -25,6 +26,7 @@ services:
 
     php:
         build: './docker/php/'
+        image: 'skeleton/php:7.2'
         environment:
             COMPOSER_CACHE_DIR: '/home/composer/.cache/composer'
             COMPOSER_HOME: '/home/composer/.config/composer'

--- a/back/docker-compose.yaml
+++ b/back/docker-compose.yaml
@@ -5,8 +5,6 @@ services:
         image: 'nginx:alpine'
         depends_on:
             - 'fpm'
-        environment:
-            PHP_IDE_CONFIG: 'serverName=app-skeleton-back'
         volumes:
             - './:/srv/app:ro'
             - './docker/nginx.conf:/etc/nginx/conf.d/default.conf:ro'

--- a/back/docker-compose.yaml
+++ b/back/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
     nginx-back:
-        image: 'nginx'
+        image: 'nginx:alpine'
         depends_on:
             - 'fpm'
         environment:
@@ -13,18 +13,39 @@ services:
             - './docker/upload.conf:/etc/nginx/conf.d/upload.conf:ro'
 
     fpm:
-        image: 'akeneo/fpm:php-7.2'
+        build: './docker/fpm/'
         environment:
+            APP_ENV: 'prod'
+            APP_SECRET: '9a1424cc2734b94f17f8374f97e50a3b'
+            DATABASE_URL: 'mysql://app-skeleton:app-skeleton@mysql:3306/app-skeleton'
+            CORS_ALLOW_ORIGIN: '^https?://localhost(:[0-9]+)?$$'
+        user: 'www-data:www-data'
+        volumes:
+            - './:/srv/app:ro'
+            - 'var-data:/srv/app/var:rw'
+        working_dir: '/srv/app'
+
+    php:
+        build: './docker/php/'
+        environment:
+            COMPOSER_CACHE_DIR: '/home/composer/.cache/composer'
+            COMPOSER_HOME: '/home/composer/.config/composer'
             PHP_IDE_CONFIG: 'serverName=app-skeleton-cli'
             XDEBUG_CONFIG: 'remote_host=172.17.0.1'
-        user: 'docker'
+        user: '$CURRENT_IDS'
         volumes:
             - './:/srv/app'
-            - '~/.cache/composer:/home/docker/.cache/composer'
-            - '~/.config/composer:/home/docker/.config/composer'
+            - '~/.cache/composer:/home/composer/.cache/composer'
+            - '~/.config/composer:/home/composer/.config/composer'
         working_dir: '/srv/app'
 
     mysql:
         image: 'mysql:5.7'
         environment:
             MYSQL_ROOT_PASSWORD: 'root'
+            MYSQL_USER: 'app-skeleton'
+            MYSQL_PASSWORD: 'app-skeleton'
+            MYSQL_DATABASE: 'app-skeleton'
+
+volumes:
+    var-data:

--- a/back/docker/fpm/Dockerfile
+++ b/back/docker/fpm/Dockerfile
@@ -1,0 +1,29 @@
+FROM php:7.2-fpm-alpine
+MAINTAINER Damien Carcel <damien.carcel@gmail.com>
+
+# Install needed PHP extensions and related libraries
+RUN apk add --no-cache \
+        icu            \
+        libintl        \
+        zlib           \
+    && apk add --no-cache --virtual .build-deps \
+       icu-dev        \
+       zlib-dev       \
+       $PHPIZE_DEPS   \
+    && docker-php-ext-install -j$(nproc) \
+        intl                             \
+        pdo                              \
+        pdo_mysql                        \
+        zip                              \
+    && pecl install apcu opcache && docker-php-ext-enable apcu opcache \
+    && apk del .build-deps
+
+# Configure PHPH
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+COPY files/app.ini $PHP_INI_DIR/conf.d/
+
+# Create volumes
+RUN mkdir -p /srv/app/var && chmod 777 /srv/app/var
+
+VOLUME /srv/app/var
+VOLUME /srv/app

--- a/back/docker/fpm/Dockerfile
+++ b/back/docker/fpm/Dockerfile
@@ -12,10 +12,11 @@ RUN apk add --no-cache \
        $PHPIZE_DEPS   \
     && docker-php-ext-install -j$(nproc) \
         intl                             \
+        opcache                          \
         pdo                              \
         pdo_mysql                        \
         zip                              \
-    && pecl install apcu opcache && docker-php-ext-enable apcu opcache \
+    && pecl install apcu && docker-php-ext-enable apcu \
     && apk del .build-deps
 
 # Configure PHPH

--- a/back/docker/fpm/files/app.ini
+++ b/back/docker/fpm/files/app.ini
@@ -1,9 +1,9 @@
-date.timezone = UTC
+date.timezone=UTC
 
-upload_max_filesize = 32M
-post_max_size = 64M
+upload_max_filesize=32M
+post_max_size=64M
 
-short_open_tag = off
+short_open_tag=off
 
 opcache.enable=1
 opcache.enable_cli=1

--- a/back/docker/fpm/files/app.ini
+++ b/back/docker/fpm/files/app.ini
@@ -1,0 +1,9 @@
+date.timezone = UTC
+
+upload_max_filesize = 32M
+post_max_size = 64M
+
+short_open_tag = off
+
+opcache.enable=1
+opcache.enable_cli=1

--- a/back/docker/nginx.conf
+++ b/back/docker/nginx.conf
@@ -8,7 +8,7 @@ server {
     }
 
     location ~ ^/index\.php(/|$) {
-        fastcgi_pass            fpm:9001;
+        fastcgi_pass            fpm:9000;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include                 fastcgi_params;
         fastcgi_param           SCRIPT_FILENAME $realpath_root$fastcgi_script_name;

--- a/back/docker/php/Dockerfile
+++ b/back/docker/php/Dockerfile
@@ -1,0 +1,30 @@
+FROM php:7.2-alpine
+MAINTAINER Damien Carcel <damien.carcel@gmail.com>
+
+# Install needed PHP extensions and related libraries
+RUN apk add --no-cache \
+        icu            \
+        libintl        \
+        zlib           \
+    && apk add --no-cache --virtual .build-deps \
+       icu-dev        \
+       zlib-dev       \
+       $PHPIZE_DEPS   \
+    && docker-php-ext-install -j$(nproc) \
+        intl                             \
+        pdo                              \
+        pdo_mysql                        \
+        zip                              \
+    && pecl install apcu opcache && docker-php-ext-enable apcu opcache \
+    && apk del .build-deps
+
+# Configure PHPH
+RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
+COPY files/app.ini $PHP_INI_DIR/conf.d/
+
+# Install composer
+RUN curl -sSL https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+RUN chmod +x /usr/local/bin/composer
+
+# Expose port for PHP internal server
+EXPOSE 8000

--- a/back/docker/php/Dockerfile
+++ b/back/docker/php/Dockerfile
@@ -12,15 +12,17 @@ RUN apk add --no-cache \
        $PHPIZE_DEPS   \
     && docker-php-ext-install -j$(nproc) \
         intl                             \
+        opcache                          \
         pdo                              \
         pdo_mysql                        \
         zip                              \
-    && pecl install apcu opcache && docker-php-ext-enable apcu opcache \
+    && pecl install apcu xdebug && docker-php-ext-enable apcu xdebug \
     && apk del .build-deps
 
 # Configure PHPH
 RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 COPY files/app.ini $PHP_INI_DIR/conf.d/
+COPY files/xdebug.ini $PHP_INI_DIR/conf.d/
 
 # Install composer
 RUN curl -sSL https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer

--- a/back/docker/php/files/app.ini
+++ b/back/docker/php/files/app.ini
@@ -1,9 +1,9 @@
-date.timezone = UTC
+date.timezone=UTC
 
-upload_max_filesize = 32M
-post_max_size = 64M
+upload_max_filesize=32M
+post_max_size=64M
 
-short_open_tag = off
+short_open_tag=off
 
 opcache.enable=1
 opcache.enable_cli=1

--- a/back/docker/php/files/app.ini
+++ b/back/docker/php/files/app.ini
@@ -1,0 +1,9 @@
+date.timezone = UTC
+
+upload_max_filesize = 32M
+post_max_size = 64M
+
+short_open_tag = off
+
+opcache.enable=1
+opcache.enable_cli=1

--- a/back/docker/php/files/xdebug.ini
+++ b/back/docker/php/files/xdebug.ini
@@ -1,0 +1,5 @@
+xdebug.default_enable=1
+xdebug.remote_enable=1
+xdebug.max_nesting_level=1000
+xdebug.idekey=XDEBUG_IDE_KEY
+xdebug.remote_connect_back=1

--- a/back/public/check.php
+++ b/back/public/check.php
@@ -1,0 +1,430 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Requirements\SymfonyRequirements;
+
+if (!isset($_SERVER['HTTP_HOST'])) {
+    exit("This script cannot be run from the CLI. Run it from a browser.\n");
+}
+
+if (!in_array(@$_SERVER['REMOTE_ADDR'], array(
+    '127.0.0.1',
+    '::1',
+))) {
+    header('HTTP/1.0 403 Forbidden');
+    exit('This script is only accessible from localhost.');
+}
+
+if (file_exists($autoloader = __DIR__.'/../../../autoload.php')) {
+    require_once $autoloader;
+} elseif (file_exists($autoloader = __DIR__.'/../vendor/autoload.php')) {
+    require_once $autoloader;
+} else {
+    throw new \RuntimeException('Unable to find the Composer autoloader.');
+}
+
+$symfonyVersion = class_exists('\Symfony\Component\HttpKernel\Kernel') ? \Symfony\Component\HttpKernel\Kernel::VERSION : null;
+
+$symfonyRequirements = new SymfonyRequirements(dirname(dirname(realpath($autoloader))), $symfonyVersion);
+
+$majorProblems = $symfonyRequirements->getFailedRequirements();
+$minorProblems = $symfonyRequirements->getFailedRecommendations();
+$hasMajorProblems = (bool) count($majorProblems);
+$hasMinorProblems = (bool) count($minorProblems);
+
+?>
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+        <meta name="robots" content="noindex,nofollow" />
+        <title>Symfony Configuration Checker</title>
+        <style>
+            /* styles copied from symfony framework bundle */
+            html {
+                background: #eee;
+            }
+            body {
+                font: 11px Verdana, Arial, sans-serif;
+                color: #333;
+            }
+            .sf-reset, .sf-reset .block, .sf-reset #message {
+                margin: auto;
+            }
+            img {
+                border: 0;
+            }
+            .clear {
+                clear: both;
+                height: 0;
+                font-size: 0;
+                line-height: 0;
+            }
+            .clear-fix:after {
+                content: "\0020";
+                display: block;
+                height: 0;
+                clear: both;
+                visibility: hidden;
+            }
+            .clear-fix {
+                display: inline-block;
+            }
+            * html .clear-fix {
+                height: 1%;
+            }
+            .clear-fix {
+                display: block;
+            }
+            .header {
+                padding: 30px 30px 20px 30px;
+            }
+            .header-logo {
+                float: left;
+            }
+            .search {
+                float: right;
+                padding-top: 20px;
+            }
+            .search label {
+                line-height: 28px;
+                vertical-align: middle;
+            }
+            .search input {
+                width: 195px;
+                font-size: 12px;
+                border: 1px solid #dadada;
+                background: #fff url(data:image/gif;base64,R0lGODlhAQAFAKIAAPX19e/v7/39/fr6+urq6gAAAAAAAAAAACH5BAAAAAAALAAAAAABAAUAAAMESAEjCQA7) repeat-x left top;
+                padding: 5px 6px;
+                color: #565656;
+            }
+            .search input[type="search"] {
+                -webkit-appearance: textfield;
+            }
+            #content {
+                width: 970px;
+                margin: 0 auto;
+            }
+            #content pre {
+                white-space: normal;
+                font-family: Arial, Helvetica, sans-serif;
+            }
+
+            /*
+            Copyright (c) 2010, Yahoo! Inc. All rights reserved.
+            Code licensed under the BSD License:
+            http://developer.yahoo.com/yui/license.html
+            version: 3.1.2
+            build: 56
+            */
+            .sf-reset div,.sf-reset dl,.sf-reset dt,.sf-reset dd,.sf-reset ul,.sf-reset ol,.sf-reset li,.sf-reset h1,.sf-reset h2,.sf-reset h3,.sf-reset h4,.sf-reset h5,.sf-reset h6,.sf-reset pre,.sf-reset code,.sf-reset form,.sf-reset fieldset,.sf-reset legend,.sf-reset input,.sf-reset textarea,.sf-reset p,.sf-reset blockquote,.sf-reset th,.sf-reset td{margin:0;padding:0;}.sf-reset table{border-collapse:collapse;border-spacing:0;}.sf-reset fieldset,.sf-reset img{border:0;}.sf-reset address,.sf-reset caption,.sf-reset cite,.sf-reset code,.sf-reset dfn,.sf-reset em,.sf-reset strong,.sf-reset th,.sf-reset var{font-style:normal;font-weight:normal;}.sf-reset li{list-style:none;}.sf-reset caption,.sf-reset th{text-align:left;}.sf-reset h1,.sf-reset h2,.sf-reset h3,.sf-reset h4,.sf-reset h5,.sf-reset h6{font-size:100%;font-weight:normal;}.sf-reset q:before,.sf-reset q:after{content:'';}.sf-reset abbr,.sf-reset acronym{border:0;font-variant:normal;}.sf-reset sup{vertical-align:text-top;}.sf-reset sub{vertical-align:text-bottom;}.sf-reset input,.sf-reset textarea,.sf-reset select{font-family:inherit;font-size:inherit;font-weight:inherit;}.sf-reset input,.sf-reset textarea,.sf-reset select{font-size:100%;}.sf-reset legend{color:#000;}
+            .sf-reset abbr {
+                border-bottom: 1px dotted #000;
+                cursor: help;
+            }
+            .sf-reset p {
+                font-size: 14px;
+                line-height: 20px;
+                padding-bottom: 20px;
+            }
+            .sf-reset strong {
+                color: #313131;
+                font-weight: bold;
+            }
+            .sf-reset a {
+                color: #6c6159;
+            }
+            .sf-reset a img {
+                border: none;
+            }
+            .sf-reset a:hover {
+                text-decoration: underline;
+            }
+            .sf-reset em {
+                font-style: italic;
+            }
+            .sf-reset h2,
+            .sf-reset h3 {
+                font-weight: bold;
+            }
+            .sf-reset h1 {
+                font-family: Georgia, "Times New Roman", Times, serif;
+                font-size: 20px;
+                color: #313131;
+                word-wrap: break-word;
+            }
+            .sf-reset li {
+                padding-bottom: 10px;
+            }
+            .sf-reset .block {
+                -moz-border-radius: 16px;
+                -webkit-border-radius: 16px;
+                border-radius: 16px;
+                margin-bottom: 20px;
+                background-color: #FFFFFF;
+                border: 1px solid #dfdfdf;
+                padding: 40px 50px;
+                word-break: break-all;
+            }
+            .sf-reset h2 {
+                font-size: 16px;
+                font-family: Arial, Helvetica, sans-serif;
+            }
+            .sf-reset li a {
+                background: none;
+                color: #868686;
+                text-decoration: none;
+            }
+            .sf-reset li a:hover {
+                background: none;
+                color: #313131;
+                text-decoration: underline;
+            }
+            .sf-reset ol {
+                padding: 10px 0;
+            }
+            .sf-reset ol li {
+                list-style: decimal;
+                margin-left: 20px;
+                padding: 2px;
+                padding-bottom: 20px;
+            }
+            .sf-reset ol ol li {
+                list-style-position: inside;
+                margin-left: 0;
+                white-space: nowrap;
+                font-size: 12px;
+                padding-bottom: 0;
+            }
+            .sf-reset li .selected {
+                background-color: #ffd;
+            }
+            .sf-button {
+                display: -moz-inline-box;
+                display: inline-block;
+                text-align: center;
+                vertical-align: middle;
+                border: 0;
+                background: transparent none;
+                text-transform: uppercase;
+                cursor: pointer;
+                font: bold 11px Arial, Helvetica, sans-serif;
+            }
+            .sf-button span {
+                text-decoration: none;
+                display: block;
+                height: 28px;
+                float: left;
+            }
+            .sf-button .border-l {
+                text-decoration: none;
+                display: block;
+                height: 28px;
+                float: left;
+                padding: 0 0 0 7px;
+                background: transparent url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAcAAAAcCAYAAACtQ6WLAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAQtJREFUeNpiPHnyJAMakARiByDWYEGT8ADiYGVlZStubm5xlv///4MEQYoKZGRkQkRERLRYWVl5wYJQyXBZWdkwCQkJUxAHKgaWlAHSLqKiosb//v1DsYMFKGCvoqJiDmQzwXTAJYECulxcXNLoumCSoszMzDzoumDGghQwYZUECWIzkrAkSIIGOmlkLI10AiX//P379x8jIyMTNmPf/v79+ysLCwsvuiQoNi5//fr1Kch4dAyS3P/gwYMTQBP+wxwHw0xA4gkQ73v9+vUZdJ2w1Lf82bNn4iCHCQoKasHsZw4ODgbRIL8c+/Lly5M3b978Y2dn5wC6npkFLXnsAOKLjx49AmUHLYAAAwBoQubG016R5wAAAABJRU5ErkJggg==) no-repeat top left;
+            }
+            .sf-button .border-r {
+                padding: 0 7px 0 0;
+                background: transparent url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAcAAAAcCAYAAACtQ6WLAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAR1JREFUeNpiPHnyZCMDA8MNID5gZmb2nAEJMH7//v3N169fX969e/cYkL8WqGAHXPLv37//QYzfv39/fvPmzbUnT56sAXInmJub/2H5/x8sx8DCwsIrISFhDmQyPX78+CmQXs70798/BmQsKipqBNTgdvz4cWkmkE5kDATMioqKZkCFdiwg1eiAi4tLGqhQF24nMmBmZuYEigth1QkEbEBxTlySYPvJkwSJ00AnjYylgU6gxB8g/oFVEphkvgLF32KNMmCCewYUv4qhEyj47+HDhyeBzIMYOoEp8CxQw56wsLAncJ1//vz5/P79+2svX74EJc2V4BT58+fPd8CE/QKYHMGJOiIiAp6oWW7evDkNSF8DZYfIyEiU7AAQYACJ2vxVdJW4eQAAAABJRU5ErkJggg==) right top no-repeat;
+            }
+            .sf-button .btn-bg {
+                padding: 0 14px;
+                color: #636363;
+                line-height: 28px;
+                background: transparent url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAcCAYAAACgXdXMAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAClJREFUeNpiPnny5EKGf//+/Wf6//8/A4QAcrGzKCZwGc9sa2urBBBgAIbDUoYVp9lmAAAAAElFTkSuQmCC) repeat-x top left;
+            }
+            .sf-button:hover .border-l,
+            .sf-button-selected .border-l {
+                background: transparent url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAcAAAAcCAYAAACtQ6WLAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAR9JREFUeNpi/P//PwMyOHfunDqQSgNiexZkibNnzxYBqZa3HOs5v7PcYQBLnjlzhg1IbfzIdsTjA/t+ht9Mr8GKwZL//v3r+sB+0OMN+zqIEf8gFMvJkyd1gXTOa9YNDP//otrPAtSV/Jp9HfPff78Z0AEL0LUeXxivMfxD0wXTqfjj/2ugkf+wSrL9/YtpJEyS4S8WI5Ek/+GR/POPFjr//cenE6/kP9q4Fo/kr39/mdj+M/zFkGQCSj5i+ccPjLJ/GBgkuYOHQR1sNDpmAkb2LBmWwL///zKCIxwZM0VHR18G6p4uxeLLAA4tJMwEshiou1iMxXaHLGswA+t/YbhORuQUv2DBAnCifvxzI+enP3dQJUFg/vz5sOzgBBBgAPxX9j0YnH4JAAAAAElFTkSuQmCC) no-repeat top left;
+            }
+            .sf-button:hover .border-r,
+            .sf-button-selected .border-r {
+                background: transparent url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAcAAAAcCAYAAACtQ6WLAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAT5JREFUeNpiPHv27BkGBoaDQDzLyMjoJgMSYHrM3WX8hn1d0f///88DFRYhSzIuv2X5H8Rg/SfKIPDTkYH/l80OINffxMTkF9O/f/8ZQPgnwyuGl+wrGd6x7vf49+9fO9jYf3+Bkkj4NesmBqAV+SdPntQC6vzHgIz//gOawbqOGchOxtAJwp8Zr4F0e7D8/fuPAR38/P8eZIo0yz8skv8YvoIk+YE6/zNgAyD7sRqLkPzzjxY6/+HS+R+fTkZ8djLh08lCUCcuSWawJGbwMTGwg7zyBatX2Bj5QZKPsBrLzaICktzN8g/NWEYGZgYZjoC/wMiei5FMpFh8QPSU6Ojoy3Cd7EwiDBJsDgxiLNY7gLrKQGIsHAxSDHxAO2TZ/b8D+TVxcXF9MCtYtLiKLgDpfUDVsxITE1GyA0CAAQA2E/N8VuHyAAAAAABJRU5ErkJggg==) right top no-repeat;
+            }
+            .sf-button:hover .btn-bg,
+            .sf-button-selected .btn-bg {
+                color: #FFFFFF;
+                text-shadow:0 1px 1px #6b9311;
+                background: transparent url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAcCAIAAAAvP0KbAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAEFJREFUeNpiPnv2LNMdvlymf///M/37B8R/QfQ/MP33L4j+B6Qh7L9//sHpf2h8MA1V+w/KRjYLaDaLCU8vQIABAFO3TxZriO4yAAAAAElFTkSuQmCC) repeat-x top left;
+            }
+
+            /* styles copied from bundles/sensiodistribution/webconfigurator/css/install.css */
+            body {
+                font-size: 14px;
+                font-family: "Lucida Sans Unicode", "Lucida Grande", Verdana, Arial, Helvetica, sans-serif;
+            }
+            .sf-reset h1.title {
+                font-size: 45px;
+                padding-bottom: 30px;
+            }
+            .sf-reset h2 {
+                font-weight: bold;
+                color: #FFFFFF;
+                /* Font is reset to sans-serif (like body) */
+                font-family: "Lucida Sans Unicode", "Lucida Grande", Verdana, Arial, Helvetica, sans-serif;
+                margin-bottom: 10px;
+                background-color: #aacd4e;
+                padding: 2px 4px;
+                display: inline-block;
+                text-transform: uppercase;
+            }
+            .sf-reset ul a,
+            .sf-reset ul a:hover {
+                background: url(../images/blue-arrow.png) no-repeat right 6px;
+                padding-right: 10px;
+            }
+            .sf-reset ul, ol {
+                padding-left: 20px;
+            }
+            .sf-reset li {
+                padding-bottom: 18px;
+            }
+            .sf-reset ol li {
+                list-style-type: decimal;
+            }
+            .sf-reset ul li {
+                list-style-type: none;
+            }
+            .sf-reset .symfony-blocks-install {
+                overflow: hidden;
+            }
+            .sf-reset .symfony-install-continue {
+                font-size: 0.95em;
+                padding-left: 0;
+            }
+            .sf-reset .symfony-install-continue li {
+                padding-bottom: 10px;
+            }
+            .sf-reset .ok {
+                color: #fff;
+                font-family: "Lucida Sans Unicode", "Lucida Grande", Verdana, Arial, Helvetica, sans-serif;
+                background-color: #6d6;
+                padding: 10px;
+                margin-bottom: 20px;
+            }
+            .sf-reset .ko {
+                background-color: #d66;
+            }
+            .sf-reset p.help {
+                padding: 12px 16px;
+                word-break: break-word;
+            }
+            .version {
+                text-align: right;
+                font-size: 10px;
+                margin-right: 20px;
+            }
+            .sf-reset a,
+            .sf-reset li a {
+                color: #08C;
+                text-decoration: none;
+            }
+            .sf-reset a:hover,
+            .sf-reset li a:hover {
+                color: #08C;
+                text-decoration: underline;
+            }
+            .sf-reset textarea {
+                padding: 7px;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="content">
+            <div class="header clear-fix">
+                <div class="header-logo">
+                    <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALYAAAA+CAMAAACxzRGDAAAAUVBMVEX////Ly8yko6WLioxkYmVXVVkwLjLl5eWxsLJKSEzy8vJxcHLY2Ni+vb89Oz9XVVh+fH+Yl5n///+xsbLY2Nlxb3KkpKWXlph+fX+LiYy+vr/IZP61AAAAAXRSTlMAQObYZgAABRBJREFUeNrVmtuWoyAQRS1FEEQSzQU7//+hYxUiXsKQZLJWM+chsUloN+WhCuguYoKyYqzmvGasKqH4HyRKxndipcgcumH8qViTM7TkUclcwaHmf5XM0eWq4km1KjdqXfMXJHVe1J3hL8lk5fCGv6wmT+o0d87U+XNrk0Y9nfv+7LM6ZJH5ZBL6LAbSxQ3Q5FDr22Skr8PQSy4n7isnsQxSX4r6pobhjCHHeDNOKrO3yGmCvZOjV9jmt8ulTdXFKdbKLNh+kOMvBzuVRa4Y7MUsdEUSWQe7xxCfZmcwjHU83LqzFvSbJQOXQvptbPnEFoyZtUUGwTeKuLuTHyT1kaP0P6cR01OKvv448gtl61dqZfmJezQmU/t+1R2fJLtBwXV6uWGwB9SZPrn0fKO2WAvQN1PUhHjTom3xgXYTkvlSKHs19OhslETq6X3HrXbjt8XbGj9b4Gi+lUAnL6XxQj8Pyk9N4Bt1xUrsLVN/3isYMug8rODMdbgOvoHs8uAb2fcANIAzkKCLYy+AXRpSU8sr1r4P67xhLgPp7vM32zlqt7Bhq2fI1Hwp+VgANxok59SsGV3oqdUL0YVDMRY7Yg8QLbVUU4NZNoOq5hJHuxEM28Sh/IyUZ8D3reR+yc58EGvOy2U0HQL6G9V+kWyEWHmzaMx6t4o9RhOm/riUiYrzqij4Ptqkn7AaCXqc+F47m04ahfde7YIz8RHEBN6BdVwdIGRVdNbKqYu1Hc0x0wBY4wqC8+XUgBGnj81SZsQB+0yAS1x/BlI/6ebHHk0lauQLuPDpu6EwAVJ7T0rl2uXa23jcqNyOZekhqYHRz3JOANrF4wCCmEs1f9D1lUe0n4NAATed80Y5e0Q7CO2TezM/BR6wKdgQzKbCF4uOQC3Bk0fKAzbFlyRWg3gksA/gmm7eOjrpaKX7fHlEW2xLbE6GZsPiCiShVzN7RG2xTz2G+OJtEqzdJ7APxy3MrSsV0VukXbKMp9lhs5BN6dr3CN+sySUaoxGwfRUM3I/gdPYONgVU+PLX4vUWm32AvUySarbONvcpV2RQEPKKjEBHFk01kQDGRblnn8ZuE9g+JUl8OWAPbkFK2K6JxhJVvF47FzYYnAN22ttwxKYCoH36rheEB7KG/HF/YUaa2G5JF+55tpyrl7B1WHM39HuP2N2EXPl1UBu8vbj4OjvD+NoTE4ssF+ScARgaJY1N7+u8bY/Y9BSM5PKwJbvMVab32YP5FB5TtcYVrGoASolVLTzI7kVsYVxRtAb5n2JXq1vCdtd47XtYItynrN0835PasLg0y13aOPbmPI+on2Lr9e5tjSHvgkAvclUjL3Fsdaw03IzgTR62yYClk7QMah4IQ0qSsoYYbOix6zJR1ZGDNMOY3Bb6W5S6jiyovep3t7bUPyoq7OkjYumrfESp8zSBc/OLosVf+nTnnKjsqR16++WDwpI8FxJWRFTlI6NKnqYJaL96TqjAbo9Toi5QiWBDcmfdFV+T8dkvFe5bItgstbM2X6QG2mVun+cazfRwOS0eiaeRRJKgLfc3BQAqfnhJyz8lfR6580SF/FXVu83Nz1xrrnFqqXL6Qxl47DNSm4RFflvN5sABDD8peouqLLKQXVdGbnqf+qIpOxON4ZyYdJEJ6sy4zS2c5eRPTT4Jyp46qDE5/ptAWqJOQ9e6yE82FXBbZCk1/tXVoshVoopE3CB0zmraI3nbqCJ/gW3ZMgtbC5nh/QHlOoOZBxQCRgAAAABJRU5ErkJggg==" alt="Symfony" />
+                </div>
+
+                <div class="search">
+                  <form method="get" action="http://symfony.com/search">
+                    <div class="form-row">
+
+                      <label for="search-id">
+                                <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAQAAAC1+jfqAAABUElEQVQoz2NgAIJ29iBdD0d7X2cPb+tY2f9MDMjgP2O2hKu7vS8CBlisZUNSMJ3fxRMkXO61wm2ue6I3iB1q8Z8ZriDZFCS03fm/wX+1/xp/TBo8QPxeqf+MUAW+QIFKj/+q/wX/c/3n/i/6Qd/bx943z/Q/K1SBI1D9fKv/AhCn/Wf5L5EHdFGKw39OqAIXoPpOMziX4T9/DFBBnuN/HqhAEtCKCNf/XDA/rZRyAmrpsvrPDVUw3wrkqCiLaewg6TohX1d7X0ffs5r/OaAKfinmgt3t4ulr4+Xg4ANip3j+l/zPArNT4LNOD0pAgWCSOUIBy3+h/+pXbBa5tni0eMx23+/mB1YSYnENroT5Pw/QSOX/mkCo+l/jgo0v2KJA643s8PgAmsMBDCbu/5xALHPB2husxN9uCzsDOgAq5kAoaZVnYMCh5Ky1r88Eh/+iABM8jUk7ClYIAAAAAElFTkSuQmCC" alt="Search on Symfony website" />
+                      </label>
+
+                      <input name="q" id="search-id" type="search" placeholder="Search on Symfony website" />
+
+                      <button type="submit" class="sf-button">
+                          <span class="border-l">
+                            <span class="border-r">
+                                <span class="btn-bg">OK</span>
+                            </span>
+                        </span>
+                      </button>
+                    </div>
+                   </form>
+                </div>
+            </div>
+
+            <div class="sf-reset">
+                <div class="block">
+                    <div class="symfony-block-content">
+                        <h1 class="title">Configuration Checker</h1>
+                        <p>
+                            This script analyzes your system to check whether is
+                            ready to run Symfony applications.
+                        </p>
+
+                        <?php if ($hasMajorProblems): ?>
+                            <h2 class="ko">Major problems</h2>
+                            <p>Major problems have been detected and <strong>must</strong> be fixed before continuing:</p>
+                            <ol>
+                                <?php foreach ($majorProblems as $problem): ?>
+                                    <li><?php echo $problem->getTestMessage() ?>
+                                        <p class="help"><em><?php echo $problem->getHelpHtml() ?></em></p>
+                                    </li>
+                                <?php endforeach; ?>
+                            </ol>
+                        <?php endif; ?>
+
+                        <?php if ($hasMinorProblems): ?>
+                            <h2>Recommendations</h2>
+                            <p>
+                                <?php if ($hasMajorProblems): ?>Additionally, to<?php else: ?>To<?php endif; ?> enhance your Symfony experience,
+                                it’s recommended that you fix the following:
+                            </p>
+                            <ol>
+                                <?php foreach ($minorProblems as $problem): ?>
+                                    <li><?php echo $problem->getTestMessage() ?>
+                                        <p class="help"><em><?php echo $problem->getHelpHtml() ?></em></p>
+                                    </li>
+                                <?php endforeach; ?>
+                            </ol>
+                        <?php endif; ?>
+
+                        <?php if ($symfonyRequirements->hasPhpConfigIssue()): ?>
+                            <p id="phpini">*
+                                <?php if ($symfonyRequirements->getPhpIniPath()): ?>
+                                    Changes to the <strong>php.ini</strong> file must be done in "<strong><?php echo $symfonyRequirements->getPhpIniPath() ?></strong>".
+                                <?php else: ?>
+                                    To change settings, create a "<strong>php.ini</strong>".
+                                <?php endif; ?>
+                            </p>
+                        <?php endif; ?>
+
+                        <?php if (!$hasMajorProblems && !$hasMinorProblems): ?>
+                            <p class="ok">All checks passed successfully. Your system is ready to run Symfony applications.</p>
+                        <?php endif; ?>
+
+                        <ul class="symfony-install-continue">
+                            <?php if ($hasMajorProblems || $hasMinorProblems): ?>
+                                <li><a href="check.php">Re-check configuration</a></li>
+                            <?php endif; ?>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/back/src/Domain/Model/User.php
+++ b/back/src/Domain/Model/User.php
@@ -19,7 +19,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 /**
  * @author Damien Carcel <damien.carcel@gmail.com>
  */
-final class User implements UserInterface
+class User implements UserInterface
 {
     /** @var UuidInterface */
     private $id;

--- a/doc/configure/docker.md
+++ b/doc/configure/docker.md
@@ -1,26 +1,22 @@
 # Run the front-end and back-end applications together using Docker
 
-## Launch the containers
-
-Both applications have their own compose files. This needs a specific configuration so they can both run on the same network and talk to each other.
-
-For both applications, copy `docker-compose.override.yaml.dist` as `docker-compose.override.yaml` (you may configure the output ports it as you see fit, but default values should work just fine).
-In the override file of the back-end application, uncomment the lines related to the networks. These commented lines allow to link the back-end application network with the one of the front-end application.
-
-Then start the containers. You must first start those of the front-end application, so the Docker network is initialized, and continue with the back-end application:
-```bash
-$ cd /path/to/the/project/front && CURRENT_IDS="$(id -u):$(id -g)" docker-compose up -d nginx-front
-$ cd /path/to/the/project/back && CURRENT_IDS="$(id -u):$(id -g)" docker-compose up -d
-```
-
 ## Configure the applications
 
-Copy the content of the file `.env.dist` into a new file `.env` for both the front-end and the back-end applications.
+For both applications, copy `docker-compose.override.yaml.dist` as `docker-compose.override.yaml`. You may configure the output ports it as you see fit, but default values should work just fine.
+
+Then copy the content of the file `.env.dist` into a new file `.env`, again for both the front-end and the back-end applications.
 
 In the back-end application, configure the environment variable `DATABASE_URL` as follow: `DATABASE_URL=mysql://app-skeleton:app-skeleton@mysql:3306/app-skeleton`.
 Those are the database name, user, and password, already configured in the compose file.
 
 In the front-end application, keep the line dedicated to [full Docker installation](https://github.com/damien-carcel/app-skeleton/blob/master/front/.env.dist#L10).
+
+## Launch the containers
+
+```bash
+$ cd /path/to/the/project/front && CURRENT_IDS="$(id -u):$(id -g)" docker-compose up -d nginx-front
+$ cd /path/to/the/project/back && CURRENT_IDS="$(id -u):$(id -g)" docker-compose up -d mysql nginx-back
+```
 
 ## Build the applications
 

--- a/doc/configure/docker.md
+++ b/doc/configure/docker.md
@@ -9,8 +9,8 @@ In the override file of the back-end application, uncomment the lines related to
 
 Then start the containers. You must first start those of the front-end application, so the Docker network is initialized, and continue with the back-end application:
 ```bash
-$ cd /path/to/the/project/front && docker-compose up -d
-$ cd /path/to/the/project/back && docker-compose up -d
+$ cd /path/to/the/project/front && CURRENT_IDS="$(id -u):$(id -g)" docker-compose up -d nginx-front
+$ cd /path/to/the/project/back && CURRENT_IDS="$(id -u):$(id -g)" docker-compose up -d
 ```
 
 ## Configure the applications
@@ -27,15 +27,15 @@ In the front-end application, keep the line dedicated to [full Docker installati
 You can now install the dependencies and build the front-end application:
 ```bash
 $ cd /path/to/the/project/front
-$ docker-compose run --rm node yarn install
-$ docker-compose run --rm node yarn run build:prod
+$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose run --rm node yarn install
+$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose run --rm node yarn run build:prod
 ```
 
 Then, install the dependencies of the back-end application and setup the database:
 ```bash
 $ cd /path/to/the/project/back
-$ docker-compose exec fpm composer update --prefer-dist --optimize-autoloader
-$ docker-compose exec fpm bin/console doctrine:schema:update --force
+$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose exec fpm composer update --prefer-dist --optimize-autoloader
+$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose exec fpm bin/console doctrine:schema:update --force
 ```
 
 You can now access the application on [localhost:8080](http://localhost:8080). You can also directly access the API on [localhost:8000](http://localhost:8000)

--- a/doc/install/back/docker.md
+++ b/doc/install/back/docker.md
@@ -13,20 +13,20 @@ Copy the file `docker-compose.override.yaml.dist` as `docker-compose.override.ya
 You may configure the nginx and MySQL output ports as you see fit.
 Then start the containers by running:
 ```bash
-$ docker-compose up -d
+$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose up -d
 ```
 
 ## Install
 
 First, install the dependencies with composer:
 ```bash
-$ docker-compose exec fpm composer update --prefer-dist --optimize-autoloader
+$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose exec fpm composer update --prefer-dist --optimize-autoloader
 ```
 
 Copy the `.env.dist` file as `.env` and configure the MySQL access by updating the `DATABASE_URL` environment variable.
 Then update the schema of the MySQL database:
 ```bash
-$ docker-compose exec fpm bin/console doctrine:schema:update --force
+$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose exec fpm bin/console doctrine:schema:update --force
 ```
 
 You can now access the application on [localhost:8000](http://localhost:8000) (`8000` being the default output of the `nginx-back` container).

--- a/doc/install/back/docker.md
+++ b/doc/install/back/docker.md
@@ -20,13 +20,25 @@ $ CURRENT_IDS="$(id -u):$(id -g)" docker-compose up -d
 
 First, install the dependencies with composer:
 ```bash
-$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose exec fpm composer update --prefer-dist --optimize-autoloader
+$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose run --rm php composer update --prefer-dist --optimize-autoloader
 ```
 
 Copy the `.env.dist` file as `.env` and configure the MySQL access by updating the `DATABASE_URL` environment variable.
 Then update the schema of the MySQL database:
 ```bash
-$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose exec fpm bin/console doctrine:schema:update --force
+$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose run --rm php bin/console doctrine:schema:update --force
 ```
 
-You can now access the application on [localhost:8000](http://localhost:8000) (`8000` being the default output of the `nginx-back` container).
+## Run the application
+
+You can either run the Symfony server (dev env, testing and developing only):
+```bash
+$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose run --rm --service-ports php bin/console server:run 0.0.0.0:8000
+```
+
+Or you can launch the `nginx` container, that will launch automatically the `fpm` container too (production like conditions):
+```bash
+$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose up -d nginx-back
+```
+
+You can now access the application on [localhost:8000](http://localhost:8000).

--- a/doc/install/back/docker.md
+++ b/doc/install/back/docker.md
@@ -5,15 +5,15 @@
 You need the latest versions of [Docker engine](https://docs.docker.com/engine/) and [Docker Compose](https://docs.docker.com/compose/) installed.
 
 The installation procedure is mostly the same than for the [local installation](https://github.com/damien-carcel/app-skeleton/blob/master/doc/install/back/local.md#install),
-except that every command is run into the `fpm` container. Also, you won't need to run the Symfony server. A `FPM` daemon and a `nginx` server are already setup.
+except that every command is run into the `fpm` container.
 
 ## Start the containers
 
 Copy the file `docker-compose.override.yaml.dist` as `docker-compose.override.yaml`.
 You may configure the nginx and MySQL output ports as you see fit.
-Then start the containers by running:
+Then start the MySQL container by running:
 ```bash
-$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose up -d
+$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose up -d mysql
 ```
 
 ## Install
@@ -36,9 +36,9 @@ You can either run the Symfony server (dev env, testing and developing only):
 $ CURRENT_IDS="$(id -u):$(id -g)" docker-compose run --rm --service-ports php bin/console server:run 0.0.0.0:8000
 ```
 
-Or you can launch the `nginx` container, that will launch automatically the `fpm` container too (production like conditions):
+Or you can launch the `nginx-back` container, that will launch automatically the `fpm` container too (production like conditions):
 ```bash
 $ CURRENT_IDS="$(id -u):$(id -g)" docker-compose up -d nginx-back
 ```
 
-You can now access the application on [localhost:8000](http://localhost:8000).
+You can now access the API on [localhost:8000](http://localhost:8000).

--- a/doc/install/back/local.md
+++ b/doc/install/back/local.md
@@ -24,4 +24,4 @@ Finally, run the Symfony built-in server:
 $ bin/console server:run
 ```
 
-You can now access the application on [localhost:8000](http://localhost:8000).
+You can now access the API on [localhost:8000](http://localhost:8000).

--- a/doc/install/front/docker.md
+++ b/doc/install/front/docker.md
@@ -10,41 +10,41 @@ The installation procedure is mostly the same than for the [local installation](
 
 Copy the file `docker-compose.override.yaml.dist` as `docker-compose.override.yaml`.
 You may configure the nginx output port as you see fit.
-Then start the containers by running:
+Then start the nginx container by running:
 ```bash
-$ docker-compose up -d
+$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose up -d nginx-front
 ```
 
 ## Install
 
 First, launch the JSON server by running:
 ```bash
-$ docker-compose run --rm node yarn run serve-api
+$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose run --rm node yarn run serve-api
 # or
-$ docker-compose run --rm node npm run serve-api
+$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose run --rm node npm run serve-api
 ```
 
 Then install the dependencies:
 ```bash
-$ docker-compose run --rm node yarn install
+$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose run --rm node yarn install
 # or
-$ docker-compose run --rm node npm install
+$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose run --rm node npm install
 ```
 
 Copy the content of the file `.env.dist` into a new file `.env`, and keep only the line dedicated to the JSON server.
 
 Finally, build the application for development (non minimized JS and CSS files) by running:
 ```bash
-$ docker-compose run --rm node yarn run build:dev
+$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose run --rm node yarn run build:dev
 # or
-$ docker-compose run --rm node npm run build:dev
+$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose run --rm node npm run build:dev
 ```
 
 or for production (minimized JS and CSS files) by running:
 ```bash
-$ docker-compose run --rm node yarn run build:prod
+$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose run --rm node yarn run build:prod
 # or
-$ docker-compose run --rm node npm run build:prod
+$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose run --rm node npm run build:prod
 ```
 
 You can now access the application on [localhost:8080](http://localhost:8080) (`8080` being the default output of the `nginx-front` container).

--- a/doc/install/front/docker.md
+++ b/doc/install/front/docker.md
@@ -17,14 +17,7 @@ $ CURRENT_IDS="$(id -u):$(id -g)" docker-compose up -d nginx-front
 
 ## Install
 
-First, launch the JSON server by running:
-```bash
-$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose run --rm node yarn run serve-api
-# or
-$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose run --rm node npm run serve-api
-```
-
-Then install the dependencies:
+First install the dependencies:
 ```bash
 $ CURRENT_IDS="$(id -u):$(id -g)" docker-compose run --rm node yarn install
 # or
@@ -33,7 +26,7 @@ $ CURRENT_IDS="$(id -u):$(id -g)" docker-compose run --rm node npm install
 
 Copy the content of the file `.env.dist` into a new file `.env`, and keep only the line dedicated to the JSON server.
 
-Finally, build the application for development (non minimized JS and CSS files) by running:
+Then build the application for development (non minimized JS and CSS files) by running:
 ```bash
 $ CURRENT_IDS="$(id -u):$(id -g)" docker-compose run --rm node yarn run build:dev
 # or
@@ -45,6 +38,13 @@ or for production (minimized JS and CSS files) by running:
 $ CURRENT_IDS="$(id -u):$(id -g)" docker-compose run --rm node yarn run build:prod
 # or
 $ CURRENT_IDS="$(id -u):$(id -g)" docker-compose run --rm node npm run build:prod
+```
+
+Finally, launch the fake JSON server by running:
+```bash
+$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose run --rm node yarn run serve-api
+# or
+$ CURRENT_IDS="$(id -u):$(id -g)" docker-compose run --rm node npm run serve-api
 ```
 
 You can now access the application on [localhost:8080](http://localhost:8080) (`8080` being the default output of the `nginx-front` container).

--- a/doc/install/front/local.md
+++ b/doc/install/front/local.md
@@ -8,14 +8,7 @@ It may work with older versions, but those are the one tested through continuous
 
 ## Install
 
-First, launch the JSON server by running:
-```bash
-$ yarn run serve-api
-# or
-$ npm run serve-api
-```
-
-Then install the dependencies:
+First, install the dependencies:
 ```bash
 $ yarn install
 # or
@@ -24,7 +17,7 @@ $ npm install
 
 Copy the content of the file `.env.dist` into a new file `.env`, and keep only the line [dedicated to the JSON server](https://github.com/damien-carcel/app-skeleton/blob/master/front/.env.dist#L4).
 
-Finally, run the test server, which will open the application in your default browser at [localhost:8080](http://localhost:8080/)`:
+Then run the test server, which will open the application in your default browser at [localhost:8080](http://localhost:8080/)`:
 ```bash
 $ yarn run serve
 # or
@@ -43,4 +36,11 @@ or for development (non minimized Javascript and CSS files) by running:
 $ yarn run build:dev
 # or
 $ npm run build:dev
+```
+
+Finally, launch the fake JSON server by running:
+```bash
+$ yarn run serve-api
+# or
+$ npm run serve-api
 ```

--- a/front/.gitignore
+++ b/front/.gitignore
@@ -1,5 +1,6 @@
 /cache
 /public
+!/public/.gitkeep
 /node_modules
 /.env.dist
 /db.json

--- a/front/docker-compose.yaml
+++ b/front/docker-compose.yaml
@@ -2,8 +2,8 @@ version: '3'
 
 services:
     node:
-        image: 'node:8'
-        user: 'node'
+        build: './docker/node/'
+        user: '${CURRENT_IDS}'
         volumes:
             - './:/home/node/app'
             - '~/.cache/yarn:/home/node/.cache/yarn'
@@ -12,7 +12,7 @@ services:
             - 'app-skeleton'
 
     nginx-front:
-        image: 'nginx'
+        image: 'nginx:alpine'
         environment:
             PHP_IDE_CONFIG: 'serverName=app-skeleton-front'
         volumes:

--- a/front/docker-compose.yaml
+++ b/front/docker-compose.yaml
@@ -3,6 +3,7 @@ version: '3'
 services:
     node:
         build: './docker/node/'
+        image: 'skeleton/node:lts'
         user: '${CURRENT_IDS}'
         volumes:
             - './:/home/node/app'

--- a/front/docker-compose.yaml
+++ b/front/docker-compose.yaml
@@ -13,8 +13,6 @@ services:
 
     nginx-front:
         image: 'nginx:alpine'
-        environment:
-            PHP_IDE_CONFIG: 'serverName=app-skeleton-front'
         volumes:
             - './public:/usr/share/nginx/html:ro'
         networks:

--- a/front/docker/node/Dockerfile
+++ b/front/docker/node/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:lts-alpine
+MAINTAINER Damien Carcel <damien.carcel@gmail.com>
+
+RUN apk add --no-cache \
+    autoconf \
+    automake \
+    bash \
+    g++ \
+    libc6-compat \
+    libjpeg-turbo-dev \
+    libpng-dev \
+    make \
+    nasm

--- a/front/webpack.config.js
+++ b/front/webpack.config.js
@@ -75,7 +75,10 @@ module.exports = (env, argv) => ({
     ]
   },
   plugins: [
-    new CleanWebpackPlugin(['public']),
+    new CleanWebpackPlugin(
+        ['public'],
+        {exclude: ['.gitkeep']},
+    ),
     new CopyWebpackPlugin([
       {from: './assets/files/humans.txt'},
       {from: './assets/files/robots.txt'}


### PR DESCRIPTION
## Description

This PR replaces `akeneo` images with new ones based on "official" Docker images. All new images are based on Alpine ones, and are stored in a `docker` sub-folder (one for the back-end application, one for the front-end one).

- [x] Replace `nginx` with `nginx:alpine`
- [x] Replace `node:8` with a custom image based on `node:lts-alpine`
- [x] Add a new "fpm" image based on `php:7.2-fpm-alpine`
- [x] Add a new "php" cli image based on `php:7.2-alpine`
- [x] add xdebug to PHP CLI image only

## Definition Of Done

| Q                 | A
| ------------------| ---
| Specifications    | -
| Acceptance tests  | -
| Integration tests | -
| System tests      | -
| Documentation     | OK
| Related tickets   | #153

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
