### PR TITLE
Issue 146: Add coupling rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,9 @@ jobs:
                 name: Run static analysis on the API
                 command: cd ~/project/api && docker-compose run --rm php vendor/bin/php-cs-fixer fix --dry-run -v --diff --config=.php_cs.php
             - run:
+                name: Run coupling detector on the API
+                command: cd ~/project/api && docker-compose run --rm php vendor/bin/php-coupling-detector detect --config-file .php_cd.php
+            - run:
                 name: Run unit tests of the API
                 command: cd ~/project/api && docker-compose run --rm php vendor/bin/phpunit --testsuite="Unit tests" --log-junit var/tests/phpunit/unit_tests.xml
             - run:

--- a/Makefile
+++ b/Makefile
@@ -105,3 +105,36 @@ down-client:
 
 .PHONY: down
 down: down-api down-client
+
+# Tests
+
+.PHONY: check-style
+check-style:
+	cd $(CURDIR)/api && docker-compose run --rm php vendor/bin/php-cs-fixer fix --dry-run -v --diff --config=.php_cs.php
+
+.PHONY: fix-style
+fix-style:
+	cd $(CURDIR)/api && docker-compose run --rm php vendor/bin/php-cs-fixer fix -v --diff --config=.php_cs.php
+
+.PHONY: coupling
+coupling:
+	cd $(CURDIR)/api && docker-compose run --rm php vendor/bin/php-coupling-detector detect --config-file .php_cd.php
+
+.PHONY: unit
+unit:
+	cd $(CURDIR)/api && docker-compose run --rm php vendor/bin/phpunit --testsuite "Unit tests"
+
+.PHONY: acceptance
+acceptance:
+	cd $(CURDIR)/api && docker-compose run --rm php vendor/bin/behat --profile=acceptance
+
+.PHONY: integration
+integration:
+	cd $(CURDIR)/api && docker-compose run --rm php vendor/bin/phpunit --testsuite="Integration tests"
+
+.PHONY: end-to-end
+end-to-end:
+	cd $(CURDIR)/api && docker-compose run --rm php vendor/bin/behat --profile=end-to-end
+
+.PHONY: test-api
+test-api: check-style coupling unit acceptance integration end-to-end

--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,10 +1,10 @@
 public/check.php
 tests
 var
-.phpspec
 .env.*
 .gitignore
 .phpunit.result.cache
+.php_cd.php
 .php_cs.cache
 .php_cs.php
 behat.yaml

--- a/api/.php_cd.php
+++ b/api/.php_cd.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Akeneo\CouplingDetector\Configuration\Configuration;
+use Akeneo\CouplingDetector\Configuration\DefaultFinder;
+use Akeneo\CouplingDetector\Domain\Rule;
+use Akeneo\CouplingDetector\Domain\RuleInterface;
+
+$finder = new DefaultFinder();
+$finder->name('*.php')->in('src');
+
+
+$rules = [
+    new Rule('Carcel\User\Domain', [
+        'Carcel\User\Domain',
+        'Ramsey\Uuid\Uuid',
+        'Symfony\Component\Security\Core\User\UserInterface',
+    ], RuleInterface::TYPE_ONLY),
+    new Rule('Carcel\User\Application', [
+        'Carcel\User\Application',
+        'Carcel\User\Domain',
+        'Ramsey\Uuid\Uuid',
+    ], RuleInterface::TYPE_ONLY),
+];
+
+return new Configuration($rules, $finder);

--- a/api/composer.json
+++ b/api/composer.json
@@ -74,21 +74,7 @@
     ],
     "post-update-cmd": [
       "@auto-scripts"
-    ],
-    "tests": [
-      "@check-style",
-      "@unit",
-      "@acceptance",
-      "@integration",
-      "@end-to-end"
-    ],
-    "check-style": "vendor/bin/php-cs-fixer fix --dry-run -v --diff --config=.php_cs.php",
-    "fix-style": "vendor/bin/php-cs-fixer fix -v --diff --config=.php_cs.php",
-    "coupling": "vendor/bin/php-coupling-detector detect --config-file .php_cd.php",
-    "unit": "vendor/bin/phpunit --testsuite \"Unit tests\"",
-    "acceptance": "vendor/bin/behat --profile=acceptance",
-    "integration": "vendor/bin/phpunit --testsuite=\"Integration tests\"",
-    "end-to-end": "vendor/bin/behat --profile=end-to-end"
+    ]
   },
   "conflict": {
     "symfony/symfony": "*"

--- a/api/composer.json
+++ b/api/composer.json
@@ -23,6 +23,7 @@
     "webmozart/assert": "^1.4"
   },
   "require-dev": {
+    "akeneo/php-coupling-detector": "^0.3.1",
     "behat/mink-browserkit-driver": "^1.3",
     "behat/mink-extension": "^2.3",
     "doctrine/doctrine-fixtures-bundle": "^3.1",
@@ -83,6 +84,7 @@
     ],
     "check-style": "vendor/bin/php-cs-fixer fix --dry-run -v --diff --config=.php_cs.php",
     "fix-style": "vendor/bin/php-cs-fixer fix -v --diff --config=.php_cs.php",
+    "coupling": "vendor/bin/php-coupling-detector detect --config-file .php_cd.php",
     "unit": "vendor/bin/phpunit --testsuite \"Unit tests\"",
     "acceptance": "vendor/bin/behat --profile=acceptance",
     "integration": "vendor/bin/phpunit --testsuite=\"Integration tests\"",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b2e4b08e5e9b847960263c3e38562f08",
+    "content-hash": "11172875854c36333d2effe19284ebab",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -4414,6 +4414,63 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "akeneo/php-coupling-detector",
+            "version": "0.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/akeneo/php-coupling-detector.git",
+                "reference": "b7f7217ebc06ab082d3deca6ccb5b6725c069044"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/akeneo/php-coupling-detector/zipball/b7f7217ebc06ab082d3deca6ccb5b6725c069044",
+                "reference": "b7f7217ebc06ab082d3deca6ccb5b6725c069044",
+                "shasum": ""
+            },
+            "require": {
+                "friendsofphp/php-cs-fixer": "^2.1",
+                "php": "^7.1",
+                "symfony/console": "^3.0||^4.0",
+                "symfony/event-dispatcher": "^3.0||^4.0",
+                "symfony/filesystem": "^3.0||^4.0",
+                "symfony/finder": "^3.0||^4.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^3.0||^4.0",
+                "phpstan/phpstan": "^0.10.2"
+            },
+            "bin": [
+                "bin/php-coupling-detector"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Akeneo\\CouplingDetector\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Dupont <nicolas@akeneo.com>",
+                    "homepage": "http://www.akeneo.com"
+                },
+                {
+                    "name": "Julien Janvier <j.janvier@gmail.com>",
+                    "homepage": "http://jjanvier.com"
+                }
+            ],
+            "description": "Detect all the coupling issues of your project with respect to the coupling rules you have defined.",
+            "time": "2018-10-16T20:00:38+00:00"
+        },
         {
             "name": "behat/behat",
             "version": "v3.5.0",

--- a/api/symfony.lock
+++ b/api/symfony.lock
@@ -1,4 +1,7 @@
 {
+    "akeneo/php-coupling-detector": {
+        "version": "0.3.1"
+    },
     "behat/behat": {
         "version": "v3.5.0"
     },


### PR DESCRIPTION
## Description

The API now has `akeneo/php-coupling-detector` ran on the CI, with a basic set of rules to ensure layers are not corrupted.

## Definition Of Done

| Q                 | A
| ------------------| ---
| Unit tests        | -
| Acceptance tests  | -
| Integration tests | -
| End to End tests  | -
| Documentation     | -
| Related tickets   | #146

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
