### PR TITLE
Issue 223: Run webpack dev server through Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ fake-api: install-client-dependencies
 
 .PHONY: develop-client
 develop-client: fake-api install-client-dependencies
-	cd $(CURDIR)/client && API_BASE_URL=http://localhost:3000 yarn webpack:serve
+	cd $(CURDIR)/client && docker-compose run --rm --service-ports node yarn webpack:serve
 
 .PHONY: serve-client
 serve-client: build-client-prod install-client-dependencies

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -86,9 +86,6 @@ RUN chmod +x /usr/local/bin/composer
 
 ENTRYPOINT ["/usr/local/bin/docker-php-entrypoint"]
 
-# Expose port for PHP internal server
-EXPOSE 8000
-
 #######################################
 # Intermediate image used to prepare  #
 # the application for production      #

--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -30,6 +30,8 @@ services:
       PHP_IDE_CONFIG: 'serverName=app-skeleton-cli'
       XDEBUG_CONFIG: 'remote_host=172.17.0.1'
       XDEBUG_ENABLED: '${XDEBUG_ENABLED:-0}'
+    expose:
+      - '8000'
     ports:
       - '${PHP_SKELETON_OUTPUT:-8000}:8000'
     user: '${HOST_USER_IDS:-1000:1000}'

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -20,8 +20,6 @@ RUN echo 'APT::Install-Recommends "0" ; APT::Install-Suggests "0" ;' > /etc/apt/
 
 RUN mkdir /.npm && chmod 777 /.npm
 
-EXPOSE 3000 8000
-
 #######################################
 # Intermediate image used to prepare  #
 # the application for production      #

--- a/client/docker-compose.yaml
+++ b/client/docker-compose.yaml
@@ -4,7 +4,15 @@ services:
   node:
     image: 'carcel/skeleton/dev:node'
     environment:
+      API_BASE_URL: 'http://0.0.0.0:${FAKE_API_PORT:-3000}'
+      CLIENT_PORT: '${CLIENT_PORT:-8080}'
       YARN_CACHE_FOLDER: '/home/yarn-cache'
+    expose:
+      - '${CLIENT_PORT:-8080}'
+    networks:
+      - skeleton-client
+    ports:
+      - '${CLIENT_PORT:-8080}:${CLIENT_PORT:-8080}'
     user: '${HOST_USER_IDS:-1000:1000}'
     volumes:
       - './:/srv/app'
@@ -12,20 +20,20 @@ services:
       - '${HOST_YARN_CONFIG_FOLDER:-~/.yarn}:/.yarn'
       - '${HOST_YARN_CONFIG_FILE:-~/.yarnrc}:/.yarnrc'
     working_dir: '/srv/app'
-    networks:
-      - skeleton-client
 
   fake-api:
-    command: 'yarn run webpack:serve-api --host 0.0.0.0'
+    command: 'yarn run webpack:serve-api -H 0.0.0.0 -p ${FAKE_API_PORT:-3000}'
+    expose:
+      - '${FAKE_API_PORT:-3000}'
     image: 'carcel/skeleton/dev:node'
+    networks:
+      - skeleton-client
     ports:
-      - '${FAKE_API_SKELETON_PORT:-3000}:3000'
+      - '${FAKE_API_PORT:-3000}:${FAKE_API_PORT:-3000}'
     user: '${HOST_USER_IDS:-1000:1000}'
     volumes:
       - './:/srv/app'
     working_dir: '/srv/app'
-    networks:
-      - skeleton-client
 
   client:
     image: 'carcel/skeleton/client:latest'

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -14,7 +14,8 @@ const WebappWebpackPlugin = require('webapp-webpack-plugin');
 module.exports = (env, argv) => ({
   devServer: {
     contentBase: path.join(__dirname, 'public'),
-    port: 8080,
+    host: '0.0.0.0',
+    port: parseInt(process.env.CLIENT_PORT || 8080),
     stats: {
       colors: true,
     },

--- a/doc/install/client.md
+++ b/doc/install/client.md
@@ -11,7 +11,8 @@ You can start the client using the `webpack-dev-server`:
 $ make develop-client
 ```
 
-This command will build the required Docker images, check that `yarn` dependencies are up to date
-and launch a fake API using the [JSON server](https://github.com/typicode/json-server).
+This command will build the required Docker images, check that `yarn` dependencies are up to date, launch a fake API
+using the [JSON server](https://github.com/typicode/json-server), and serve the application using the Webpack dev server
+with hot reloading.
 
 You can access the client application on [localhost:8080](http://localhost:8080).


### PR DESCRIPTION
## Description

This PR allows running the Webpack development server through Docker, while still enabling hot reload in the web browser.

## Definition Of Done

| Q                 | A
| ------------------| ---
| Unit tests        | -
| Acceptance tests  | -
| Integration tests | -
| End to End tests  | -
| Documentation     | OK
| Related tickets   | #223

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
