### PR TITLE
Issue 147: Use Symfony Messenger

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -30,3 +30,10 @@ DATABASE_URL=mysql://app_skeleton:app_skeleton@mysql:3306/app_skeleton
 ###> nelmio/cors-bundle ###
 CORS_ALLOW_ORIGIN='^https?://skeleton.docker.localhost(:[0-9]+)?$$'
 ###< nelmio/cors-bundle ###
+
+###> symfony/messenger ###
+# Choose one of the transports below
+# MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/messages
+# MESSENGER_TRANSPORT_DSN=doctrine://default
+# MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages
+###< symfony/messenger ###

--- a/api/.php_cd.php
+++ b/api/.php_cd.php
@@ -6,6 +6,9 @@ use Akeneo\CouplingDetector\Configuration\Configuration;
 use Akeneo\CouplingDetector\Configuration\DefaultFinder;
 use Akeneo\CouplingDetector\Domain\Rule;
 use Akeneo\CouplingDetector\Domain\RuleInterface;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Webmozart\Assert\Assert;
 
 $finder = new DefaultFinder();
 $finder->name('*.php')->in('src');
@@ -15,12 +18,13 @@ $rules = [
     new Rule('Carcel\User\Domain', [
         'Carcel\User\Domain',
         'Ramsey\Uuid\Uuid',
-        'Webmozart\Assert\Assert',
+        Assert::class,
     ], RuleInterface::TYPE_ONLY),
     new Rule('Carcel\User\Application', [
         'Carcel\User\Application',
         'Carcel\User\Domain',
-        'Ramsey\Uuid\Uuid',
+        Uuid::class,
+        MessageHandlerInterface::class,
     ], RuleInterface::TYPE_ONLY),
 ];
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -66,7 +66,8 @@ ENV XDEBUG_ENABLED=0
 RUN apt-get update && \
     apt-get --yes install \
         git \
-        php7.3-xdebug && \
+        php7.3-xdebug \
+        unzip && \
     apt-get clean && \
     apt-get --yes autoremove --purge && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \

--- a/api/composer.json
+++ b/api/composer.json
@@ -15,6 +15,7 @@
     "symfony/dotenv": "4.3.*",
     "symfony/flex": "^1.2",
     "symfony/framework-bundle": "4.3.*",
+    "symfony/messenger": "4.3.*",
     "symfony/monolog-bundle": "^3.3",
     "symfony/orm-pack": "^1.0",
     "symfony/security-bundle": "4.3.*",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "11172875854c36333d2effe19284ebab",
+    "content-hash": "5bc1122f9bc38c4877d6175402936f96",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -2950,6 +2950,80 @@
                 "words"
             ],
             "time": "2019-09-17T11:12:06+00:00"
+        },
+        {
+            "name": "symfony/messenger",
+            "version": "v4.3.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/messenger.git",
+                "reference": "6b963b69ba96482e35a7c81fc8c9ef1a9bc9052a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/messenger/zipball/6b963b69ba96482e35a7c81fc8c9ef1a9bc9052a",
+                "reference": "6b963b69ba96482e35a7c81fc8c9ef1a9bc9052a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "psr/log": "~1.0"
+            },
+            "conflict": {
+                "symfony/debug": "<4.1",
+                "symfony/event-dispatcher": "<4.3"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^2.6",
+                "psr/cache": "~1.0",
+                "symfony/console": "~3.4|~4.0",
+                "symfony/debug": "~4.1",
+                "symfony/dependency-injection": "~3.4.19|^4.1.8",
+                "symfony/doctrine-bridge": "~3.4|~4.0",
+                "symfony/event-dispatcher": "~4.3",
+                "symfony/http-kernel": "~3.4|~4.0",
+                "symfony/process": "~3.4|~4.0",
+                "symfony/property-access": "~3.4|~4.0",
+                "symfony/serializer": "~3.4|~4.0",
+                "symfony/service-contracts": "^1.1",
+                "symfony/stopwatch": "~3.4|~4.0",
+                "symfony/validator": "~3.4|~4.0",
+                "symfony/var-dumper": "~3.4|~4.0"
+            },
+            "suggest": {
+                "enqueue/messenger-adapter": "For using the php-enqueue library as a transport."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Messenger\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Samuel Roze",
+                    "email": "samuel.roze@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Messenger Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-10-30T12:58:49+00:00"
         },
         {
             "name": "symfony/mime",

--- a/api/config/packages/messenger.yaml
+++ b/api/config/packages/messenger.yaml
@@ -1,0 +1,14 @@
+framework:
+    messenger:
+        # Uncomment this (and the failed transport below) to send failed messages to this transport for later handling.
+        # failure_transport: failed
+
+        transports:
+            # https://symfony.com/doc/current/messenger.html#transport-configuration
+            # async: '%env(MESSENGER_TRANSPORT_DSN)%'
+            # failed: 'doctrine://default?queue_name=failed'
+            # sync: 'sync://'
+
+        routing:
+            # Route your messages to the transports
+            # 'App\Message\YourMessage': async

--- a/api/config/packages/prod/monolog.yaml
+++ b/api/config/packages/prod/monolog.yaml
@@ -4,12 +4,12 @@ monolog:
             type: fingers_crossed
             action_level: error
             handler: nested
-            excluded_404s:
-                # regex: exclude all 404 errors from the logs
-                - ^/
+#            excluded_404s:
+#                # regex: exclude all 404 errors from the logs
+#                - ^/
         nested:
             type: stream
-            path: "%kernel.logs_dir%/%kernel.environment%.log"
+            path: "php://stderr"
             level: debug
         console:
             type: console
@@ -17,7 +17,7 @@ monolog:
             channels: ["!event", "!doctrine"]
         deprecation:
             type: stream
-            path: "%kernel.logs_dir%/%kernel.environment%.deprecations.log"
+            path: "php://stderr"
         deprecation_filter:
             type: filter
             handler: deprecation

--- a/api/phpunit.xml
+++ b/api/phpunit.xml
@@ -11,6 +11,13 @@
         <ini name="error_reporting" value="-1" />
         <server name="APP_ENV" value="integration" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
+
+        <!-- ###+ symfony/messenger ### -->
+        <!-- Choose one of the transports below -->
+        <!-- MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/messages -->
+        <!-- MESSENGER_TRANSPORT_DSN=doctrine://default -->
+        <!-- MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages -->
+        <!-- ###- symfony/messenger ### -->
     </php>
 
     <testsuites>

--- a/api/src/User/Application/Command/CreateUserHandler.php
+++ b/api/src/User/Application/Command/CreateUserHandler.php
@@ -19,11 +19,12 @@ use Carcel\User\Domain\Model\Write\LastName;
 use Carcel\User\Domain\Model\Write\User;
 use Carcel\User\Domain\Repository\UserRepositoryInterface;
 use Ramsey\Uuid\Uuid;
+use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
 /**
  * @author Damien Carcel <damien.carcel@gmail.com>
  */
-final class CreateUserHandler
+final class CreateUserHandler implements MessageHandlerInterface
 {
     private $userRepository;
 

--- a/api/src/User/Application/Command/DeleteUserHandler.php
+++ b/api/src/User/Application/Command/DeleteUserHandler.php
@@ -15,11 +15,12 @@ namespace Carcel\User\Application\Command;
 
 use Carcel\User\Domain\Exception\UserDoesNotExist;
 use Carcel\User\Domain\Repository\UserRepositoryInterface;
+use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
 /**
  * @author Damien Carcel <damien.carcel@gmail.com>
  */
-final class DeleteUserHandler
+final class DeleteUserHandler implements MessageHandlerInterface
 {
     private $userRepository;
 

--- a/api/src/User/Application/Command/UpdateUserDataHandler.php
+++ b/api/src/User/Application/Command/UpdateUserDataHandler.php
@@ -18,11 +18,12 @@ use Carcel\User\Domain\Model\Write\Email;
 use Carcel\User\Domain\Model\Write\FirstName;
 use Carcel\User\Domain\Model\Write\LastName;
 use Carcel\User\Domain\Repository\UserRepositoryInterface;
+use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
 /**
  * @author Damien Carcel <damien.carcel@gmail.com>
  */
-final class UpdateUserDataHandler
+final class UpdateUserDataHandler implements MessageHandlerInterface
 {
     private $userRepository;
 

--- a/api/src/User/Application/Query/GetUserHandler.php
+++ b/api/src/User/Application/Query/GetUserHandler.php
@@ -16,11 +16,12 @@ namespace Carcel\User\Application\Query;
 use Carcel\User\Domain\Exception\UserDoesNotExist;
 use Carcel\User\Domain\Model\Read\User;
 use Carcel\User\Domain\QueryFunction\GetUser as GetUserQueryFunction;
+use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
 /**
  * @author Damien Carcel <damien.carcel@gmail.com>
  */
-final class GetUserHandler
+final class GetUserHandler implements MessageHandlerInterface
 {
     private $getUserQueryFunction;
 

--- a/api/src/User/Application/Query/GetUserListHandler.php
+++ b/api/src/User/Application/Query/GetUserListHandler.php
@@ -15,11 +15,12 @@ namespace Carcel\User\Application\Query;
 
 use Carcel\User\Domain\Model\Read\UserList;
 use Carcel\User\Domain\QueryFunction\GetUserList as GetUserListQueryFunction;
+use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
 /**
  * @author Damien Carcel <damien.carcel@gmail.com>
  */
-final class GetUserListHandler
+final class GetUserListHandler implements MessageHandlerInterface
 {
     private $getUserListQueryFunction;
 

--- a/api/src/User/Infrastructure/API/Controller/User/CreateController.php
+++ b/api/src/User/Infrastructure/API/Controller/User/CreateController.php
@@ -18,6 +18,7 @@ use Carcel\User\Application\Command\CreateUserHandler;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
@@ -39,12 +40,16 @@ final class CreateController
         $content = $request->getContent();
         $userData = json_decode($content, true);
 
-        $createUser = new CreateUser(
-            $userData['email'],
-            $userData['firstName'],
-            $userData['lastName']
-        );
-        ($this->createUserHandler)($createUser);
+        try {
+            $createUser = new CreateUser(
+                $userData['email'],
+                $userData['firstName'],
+                $userData['lastName']
+            );
+            ($this->createUserHandler)($createUser);
+        } catch (\InvalidArgumentException $exception) {
+            throw new BadRequestHttpException($exception->getMessage(), $exception);
+        }
 
         return new JsonResponse();
     }

--- a/api/src/User/Infrastructure/API/Controller/User/UpdateController.php
+++ b/api/src/User/Infrastructure/API/Controller/User/UpdateController.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Carcel\User\Infrastructure\API\Controller\User;
 
 use Carcel\User\Application\Command\UpdateUserData;
-use Carcel\User\Application\Command\UpdateUserDataHandler;
 use Carcel\User\Domain\Exception\UserDoesNotExist;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -22,6 +21,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
@@ -31,14 +32,7 @@ use Symfony\Component\Routing\Annotation\Route;
  */
 final class UpdateController
 {
-    private $changeUserNameHandler;
-
-    public function __construct(UpdateUserDataHandler $changeUserNameHandler)
-    {
-        $this->changeUserNameHandler = $changeUserNameHandler;
-    }
-
-    public function __invoke(string $uuid, Request $request): Response
+    public function __invoke(string $uuid, Request $request, MessageBusInterface $bus): Response
     {
         $content = $request->getContent();
         $userData = json_decode($content, true);
@@ -50,10 +44,14 @@ final class UpdateController
                 $userData['firstName'],
                 $userData['lastName']
             );
-            ($this->changeUserNameHandler)($changeUserName);
-        } catch (UserDoesNotExist $exception) {
-            throw new NotFoundHttpException($exception->getMessage(), $exception);
-        } catch (\InvalidArgumentException $exception) {
+            $bus->dispatch($changeUserName);
+        } catch (HandlerFailedException $exception) {
+            $handledExceptions = $exception->getNestedExceptions();
+
+            if (current($handledExceptions) instanceof UserDoesNotExist) {
+                throw new NotFoundHttpException($exception->getMessage(), $exception);
+            }
+
             throw new BadRequestHttpException($exception->getMessage(), $exception);
         }
 

--- a/api/src/User/Infrastructure/API/Controller/User/UpdateController.php
+++ b/api/src/User/Infrastructure/API/Controller/User/UpdateController.php
@@ -20,6 +20,7 @@ use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -52,6 +53,8 @@ final class UpdateController
             ($this->changeUserNameHandler)($changeUserName);
         } catch (UserDoesNotExist $exception) {
             throw new NotFoundHttpException($exception->getMessage(), $exception);
+        } catch (\InvalidArgumentException $exception) {
+            throw new BadRequestHttpException($exception->getMessage(), $exception);
         }
 
         return new JsonResponse();

--- a/api/symfony.lock
+++ b/api/symfony.lock
@@ -382,6 +382,18 @@
     "symfony/inflector": {
         "version": "v4.2.3"
     },
+    "symfony/messenger": {
+        "version": "4.3",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "4.3",
+            "ref": "8a2675c061737658bed85102e9241c752620e575"
+        },
+        "files": [
+            "config/packages/messenger.yaml"
+        ]
+    },
     "symfony/mime": {
         "version": "v4.3.0"
     },

--- a/api/tests/acceptance/Context/CreateUserContext.php
+++ b/api/tests/acceptance/Context/CreateUserContext.php
@@ -16,9 +16,9 @@ namespace Carcel\Tests\Acceptance\Context;
 use Behat\Behat\Context\Context;
 use Carcel\Tests\Fixtures\UserFixtures;
 use Carcel\User\Application\Command\CreateUser;
-use Carcel\User\Application\Command\CreateUserHandler;
 use Carcel\User\Domain\Model\Write\User;
 use Carcel\User\Domain\Repository\UserRepositoryInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Webmozart\Assert\Assert;
 
 /**
@@ -32,12 +32,12 @@ final class CreateUserContext implements Context
         'lastName' => 'Wayne',
     ];
 
-    private $createUserHandler;
+    private $bus;
     private $userRepository;
 
-    public function __construct(CreateUserHandler $createUserHandler, UserRepositoryInterface $userRepository)
+    public function __construct(MessageBusInterface $bus, UserRepositoryInterface $userRepository)
     {
-        $this->createUserHandler = $createUserHandler;
+        $this->bus = $bus;
         $this->userRepository = $userRepository;
     }
 
@@ -52,7 +52,7 @@ final class CreateUserContext implements Context
             static::NEW_USER['lastName']
         );
 
-        ($this->createUserHandler)($createUser);
+        $this->bus->dispatch($createUser);
     }
 
     /**


### PR DESCRIPTION
## Description

This PR adds the Messenger component to the API, using it to handle queries and commands through the default message bus.

The bus is used both in API controllers and in Behat acceptance contexts.

## Definition Of Done

| Q                 | A
| ------------------| ---
| Unit tests        | -
| Acceptance tests  | OK
| Integration tests | -
| End to End tests  | -
| Documentation     | -
| Related tickets   | #147

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
