### PR TITLE
Issue 148: Always use HTTPS with Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ build-client-dev: pull-client
 
 .PHONY: build-client-prod
 build-client-prod: pull-client
-	cd $(CURDIR)/client && DOCKER_BUILDKIT=1 docker build --pull . --tag carcel/skeleton/client:latest --build-arg API_BASE_URL_FOR_PRODUCTION="http://skeleton-api.docker.localhost" --target client
+	cd $(CURDIR)/client && DOCKER_BUILDKIT=1 docker build --pull . --tag carcel/skeleton/client:latest --build-arg API_BASE_URL_FOR_PRODUCTION="https://skeleton-api.docker.localhost" --target client
 
 .PHONY: build-dev
 build-dev: build-api-dev build-client-dev

--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -6,7 +6,13 @@ services:
     depends_on:
       - 'fpm'
     labels:
+      - 'traefik.http.middlewares.redirect-skeleton-api-http-to-https.redirectScheme.scheme=https'
+      - 'traefik.http.routers.skeleton-api.entrypoints=web'
+      - 'traefik.http.routers.skeleton-api.middlewares=redirect-skeleton-api-http-to-https'
       - 'traefik.http.routers.skeleton-api.rule=Host(`skeleton-api.docker.localhost`)'
+      - 'traefik.http.routers.skeleton-api-with-https.entrypoints=websecure'
+      - 'traefik.http.routers.skeleton-api-with-https.rule=Host(`skeleton-api.docker.localhost`)'
+      - 'traefik.http.routers.skeleton-api-with-https.tls=true'
     networks:
       - proxy
       - skeleton-api

--- a/client/docker-compose.yaml
+++ b/client/docker-compose.yaml
@@ -38,7 +38,13 @@ services:
   client:
     image: 'carcel/skeleton/client:latest'
     labels:
+      - 'traefik.http.middlewares.redirect-skeleton-client-http-to-https.redirectScheme.scheme=https'
+      - 'traefik.http.routers.skeleton-client.entrypoints=web'
+      - 'traefik.http.routers.skeleton-client.middlewares=redirect-skeleton-client-http-to-https'
       - 'traefik.http.routers.skeleton-client.rule=Host(`skeleton.docker.localhost`)'
+      - 'traefik.http.routers.skeleton-client-with-https.entrypoints=websecure'
+      - 'traefik.http.routers.skeleton-client-with-https.rule=Host(`skeleton.docker.localhost`)'
+      - 'traefik.http.routers.skeleton-client-with-https.tls=true'
     networks:
       - proxy
       - skeleton-client


### PR DESCRIPTION
## Description

Use recently updates [Traefik configuration](https://github.com/damien-carcel/traefik-as-local-reverse-proxy) to access the application through HTTPS. Client and API also communicates through HTTPS only.

## Definition Of Done

| Q                 | A
| ------------------| ---
| Unit tests        | -
| Acceptance tests  | -
| Integration tests | -
| End to End tests  | -
| Documentation     | -
| Related tickets   | #148

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
