### PR TITLE
Issue 231: Refactoring the use of UUIDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,22 +60,22 @@ update-dependencies: update-api-dependencies update-client-dependencies
 
 # Serve the applications
 
-.PHONY: mysql	# It should depends on "install-api-dependencies" because it uses PHP dev image, but this make the CI build this image twice
-mysql:
+.PHONY: mysql
+mysql: install-api-dependencies
 	cd ${CURDIR}/api && docker-compose up -d mysql
 	sh ${CURDIR}/api/docker/mysql/wait_for_it.sh
 	cd ${CURDIR}/api && docker-compose run --rm php bin/console doctrine:schema:update --force
 
 .PHONY: develop-api
-develop-api: install-api-dependencies mysql
+develop-api: mysql
 	cd ${CURDIR}/api && docker-compose run --rm --service-ports php bin/console server:run 0.0.0.0:8000
 
 .PHONY: debug-api
-debug-api: install-api-dependencies mysql
+debug-api: mysql
 	cd ${CURDIR}/api && docker-compose run --rm --service-ports -e XDEBUG_ENABLED=1 php bin/console server:run 0.0.0.0:8000
 
 .PHONY: serve-api
-serve-api: build-api-prod install-api-dependencies mysql
+serve-api: build-api-prod mysql
 	cd ${CURDIR}/api && docker-compose up -d api
 
 .PHONY: fake-api

--- a/api/src/User/Application/Command/DeleteUser.php
+++ b/api/src/User/Application/Command/DeleteUser.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Carcel\User\Application\Command;
 
-use Ramsey\Uuid\UuidInterface;
-
 /**
  * @author Damien Carcel <damien.carcel@gmail.com>
  */
@@ -22,12 +20,12 @@ final class DeleteUser
 {
     private $identifier;
 
-    public function __construct(UuidInterface $identifier)
+    public function __construct(string $identifier)
     {
         $this->identifier = $identifier;
     }
 
-    public function identifier(): UuidInterface
+    public function identifier(): string
     {
         return $this->identifier;
     }

--- a/api/src/User/Application/Command/DeleteUserHandler.php
+++ b/api/src/User/Application/Command/DeleteUserHandler.php
@@ -15,6 +15,7 @@ namespace Carcel\User\Application\Command;
 
 use Carcel\User\Domain\Exception\UserDoesNotExist;
 use Carcel\User\Domain\Repository\UserRepositoryInterface;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
 /**
@@ -31,7 +32,7 @@ final class DeleteUserHandler implements MessageHandlerInterface
 
     public function __invoke(DeleteUser $deleteUser): void
     {
-        $user = $this->userRepository->find((string) $deleteUser->identifier());
+        $user = $this->userRepository->find(Uuid::fromString($deleteUser->identifier()));
         if (null === $user) {
             throw UserDoesNotExist::fromUuid($deleteUser->identifier());
         }

--- a/api/src/User/Application/Command/DeleteUserHandler.php
+++ b/api/src/User/Application/Command/DeleteUserHandler.php
@@ -31,7 +31,7 @@ final class DeleteUserHandler implements MessageHandlerInterface
 
     public function __invoke(DeleteUser $deleteUser): void
     {
-        $user = $this->userRepository->find($deleteUser->identifier()->toString());
+        $user = $this->userRepository->find((string) $deleteUser->identifier());
         if (null === $user) {
             throw UserDoesNotExist::fromUuid($deleteUser->identifier());
         }

--- a/api/src/User/Application/Command/UpdateUserData.php
+++ b/api/src/User/Application/Command/UpdateUserData.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Carcel\User\Application\Command;
 
-use Ramsey\Uuid\UuidInterface;
-
 /**
  * @author Damien Carcel <damien.carcel@gmail.com>
  */
@@ -25,7 +23,7 @@ final class UpdateUserData
     private $firstName;
     private $lastName;
 
-    public function __construct(UuidInterface $identifier, string $email, string $firstName, string $lastName)
+    public function __construct(string $identifier, string $email, string $firstName, string $lastName)
     {
         $this->identifier = $identifier;
         $this->email = $email;
@@ -33,7 +31,7 @@ final class UpdateUserData
         $this->lastName = $lastName;
     }
 
-    public function identifier(): UuidInterface
+    public function identifier(): string
     {
         return $this->identifier;
     }

--- a/api/src/User/Application/Command/UpdateUserDataHandler.php
+++ b/api/src/User/Application/Command/UpdateUserDataHandler.php
@@ -18,6 +18,7 @@ use Carcel\User\Domain\Model\Write\Email;
 use Carcel\User\Domain\Model\Write\FirstName;
 use Carcel\User\Domain\Model\Write\LastName;
 use Carcel\User\Domain\Repository\UserRepositoryInterface;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
 /**
@@ -34,7 +35,7 @@ final class UpdateUserDataHandler implements MessageHandlerInterface
 
     public function __invoke(UpdateUserData $changeUserName): void
     {
-        $user = $this->userRepository->find((string) $changeUserName->identifier());
+        $user = $this->userRepository->find(Uuid::fromString($changeUserName->identifier()));
         if (null === $user) {
             throw UserDoesNotExist::fromUuid($changeUserName->identifier());
         }

--- a/api/src/User/Application/Command/UpdateUserDataHandler.php
+++ b/api/src/User/Application/Command/UpdateUserDataHandler.php
@@ -40,11 +40,11 @@ final class UpdateUserDataHandler implements MessageHandlerInterface
             throw UserDoesNotExist::fromUuid($changeUserName->identifier());
         }
 
-        $email = Email::fromString($changeUserName->email());
         $firstName = FirstName::fromString($changeUserName->firstName());
         $lastName = LastName::fromString($changeUserName->lastName());
+        $email = Email::fromString($changeUserName->email());
 
-        $user->update($email, $firstName, $lastName);
+        $user->update($firstName, $lastName, $email);
 
         $this->userRepository->save($user);
     }

--- a/api/src/User/Application/Command/UpdateUserDataHandler.php
+++ b/api/src/User/Application/Command/UpdateUserDataHandler.php
@@ -34,7 +34,7 @@ final class UpdateUserDataHandler implements MessageHandlerInterface
 
     public function __invoke(UpdateUserData $changeUserName): void
     {
-        $user = $this->userRepository->find($changeUserName->identifier()->toString());
+        $user = $this->userRepository->find((string) $changeUserName->identifier());
         if (null === $user) {
             throw UserDoesNotExist::fromUuid($changeUserName->identifier());
         }

--- a/api/src/User/Application/Query/GetUser.php
+++ b/api/src/User/Application/Query/GetUser.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Carcel\User\Application\Query;
 
-use Ramsey\Uuid\UuidInterface;
-
 /**
  * @author Damien Carcel <damien.carcel@gmail.com>
  */
@@ -22,12 +20,12 @@ final class GetUser
 {
     private $identifier;
 
-    public function __construct(UuidInterface $identifier)
+    public function __construct(string $identifier)
     {
         $this->identifier = $identifier;
     }
 
-    public function identifier(): UuidInterface
+    public function identifier(): string
     {
         return $this->identifier;
     }

--- a/api/src/User/Application/Query/GetUserHandler.php
+++ b/api/src/User/Application/Query/GetUserHandler.php
@@ -16,6 +16,7 @@ namespace Carcel\User\Application\Query;
 use Carcel\User\Domain\Exception\UserDoesNotExist;
 use Carcel\User\Domain\Model\Read\User;
 use Carcel\User\Domain\QueryFunction\GetUser as GetUserQueryFunction;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
 /**
@@ -34,7 +35,7 @@ final class GetUserHandler implements MessageHandlerInterface
     {
         $uuid = $getUser->identifier();
 
-        if (null === $user = ($this->getUserQueryFunction)($uuid)) {
+        if (null === $user = ($this->getUserQueryFunction)(Uuid::fromString($uuid))) {
             throw UserDoesNotExist::fromUuid($uuid);
         }
 

--- a/api/src/User/Domain/Exception/UserDoesNotExist.php
+++ b/api/src/User/Domain/Exception/UserDoesNotExist.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Carcel\User\Domain\Exception;
 
-use Ramsey\Uuid\UuidInterface;
-
 /**
  * @author Damien Carcel <damien.carcel@gmail.com>
  */
@@ -25,8 +23,8 @@ final class UserDoesNotExist extends \InvalidArgumentException
         parent::__construct(sprintf('There is no user with identifier "%s"', $identifier));
     }
 
-    public static function fromUuid(UuidInterface $uuid): self
+    public static function fromUuid(string $uuid): self
     {
-        return new self((string) $uuid);
+        return new self($uuid);
     }
 }

--- a/api/src/User/Domain/Exception/UserDoesNotExist.php
+++ b/api/src/User/Domain/Exception/UserDoesNotExist.php
@@ -27,6 +27,6 @@ final class UserDoesNotExist extends \InvalidArgumentException
 
     public static function fromUuid(UuidInterface $uuid): self
     {
-        return new self($uuid->toString());
+        return new self((string) $uuid);
     }
 }

--- a/api/src/User/Domain/Factory/UserFactory.php
+++ b/api/src/User/Domain/Factory/UserFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of app-skeleton.
+ *
+ * Copyright (c) 2019 Damien Carcel <damien.carcel@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Carcel\User\Domain\Factory;
+
+use Carcel\User\Domain\Model\Write\Email;
+use Carcel\User\Domain\Model\Write\FirstName;
+use Carcel\User\Domain\Model\Write\LastName;
+use Carcel\User\Domain\Model\Write\User;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * @author Damien Carcel <damien.carcel@gmail.com>
+ */
+final class UserFactory
+{
+    public function create(string $id, string $firstName, string $lastName, string $email): User
+    {
+        return new User(
+            Uuid::fromString($id),
+            FirstName::fromString($firstName),
+            LastName::fromString($lastName),
+            Email::fromString($email),
+        );
+    }
+}

--- a/api/src/User/Domain/Model/Read/UserList.php
+++ b/api/src/User/Domain/Model/Read/UserList.php
@@ -34,10 +34,8 @@ final class UserList
 
     public function normalize(): array
     {
-        $normalizedUsers = array_map(function (User $user) {
+        return array_map(function (User $user) {
             return $user->normalize();
         }, $this->users);
-
-        return $normalizedUsers;
     }
 }

--- a/api/src/User/Domain/Model/Write/User.php
+++ b/api/src/User/Domain/Model/Write/User.php
@@ -23,30 +23,25 @@ use Ramsey\Uuid\UuidInterface;
 class User
 {
     private $id;
-    private $email;
     private $firstName;
     private $lastName;
+    private $email;
 
     public function __construct(
         UuidInterface $id,
-        Email $email,
         FirstName $firstName,
-        LastName $lastName
+        LastName $lastName,
+        Email $email
     ) {
         $this->id = $id;
-        $this->email = $email;
         $this->firstName = $firstName;
         $this->lastName = $lastName;
+        $this->email = $email;
     }
 
     public function id(): UuidInterface
     {
         return $this->id;
-    }
-
-    public function email(): Email
-    {
-        return $this->email;
     }
 
     public function firstName(): FirstName
@@ -59,10 +54,15 @@ class User
         return $this->lastName;
     }
 
-    public function update(Email $email, FirstName $firstName, LastName $lastName): void
+    public function email(): Email
     {
-        $this->email = $email;
+        return $this->email;
+    }
+
+    public function update(FirstName $firstName, LastName $lastName, Email $email): void
+    {
         $this->firstName = $firstName;
         $this->lastName = $lastName;
+        $this->email = $email;
     }
 }

--- a/api/src/User/Domain/Repository/UserRepositoryInterface.php
+++ b/api/src/User/Domain/Repository/UserRepositoryInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Carcel\User\Domain\Repository;
 
 use Carcel\User\Domain\Model\Write\User;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * @author Damien Carcel <damien.carcel@gmail.com>
@@ -28,7 +29,7 @@ interface UserRepositoryInterface
     /**
      * @return User
      */
-    public function find(string $uuid): ?User;
+    public function find(UuidInterface $uuid): ?User;
 
     public function save(User $user): void;
 

--- a/api/src/User/Infrastructure/API/Controller/User/DeleteController.php
+++ b/api/src/User/Infrastructure/API/Controller/User/DeleteController.php
@@ -15,7 +15,6 @@ namespace Carcel\User\Infrastructure\API\Controller\User;
 
 use Carcel\User\Application\Command\DeleteUser;
 use Carcel\User\Domain\Exception\UserDoesNotExist;
-use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -34,7 +33,7 @@ final class DeleteController
     public function __invoke(string $uuid, MessageBusInterface $bus): Response
     {
         try {
-            $deleteUser = new DeleteUser(Uuid::fromString($uuid));
+            $deleteUser = new DeleteUser($uuid);
             $bus->dispatch($deleteUser);
         } catch (HandlerFailedException $exception) {
             $handledExceptions = $exception->getNestedExceptions();

--- a/api/src/User/Infrastructure/API/Controller/User/GetController.php
+++ b/api/src/User/Infrastructure/API/Controller/User/GetController.php
@@ -16,7 +16,6 @@ namespace Carcel\User\Infrastructure\API\Controller\User;
 use Carcel\User\Application\Query\GetUser;
 use Carcel\User\Domain\Exception\UserDoesNotExist;
 use Carcel\User\Domain\Model\Read\User;
-use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -37,7 +36,7 @@ final class GetController
     public function __invoke(string $uuid, MessageBusInterface $bus): Response
     {
         try {
-            $envelope = $bus->dispatch(new GetUser(Uuid::fromString($uuid)));
+            $envelope = $bus->dispatch(new GetUser($uuid));
         } catch (HandlerFailedException $exception) {
             $handledExceptions = $exception->getNestedExceptions();
 

--- a/api/src/User/Infrastructure/API/Controller/User/UpdateController.php
+++ b/api/src/User/Infrastructure/API/Controller/User/UpdateController.php
@@ -39,7 +39,7 @@ final class UpdateController
 
         try {
             $changeUserName = new UpdateUserData(
-                Uuid::fromString($uuid),
+                $uuid,
                 $userData['email'],
                 $userData['firstName'],
                 $userData['lastName']

--- a/api/src/User/Infrastructure/Persistence/Doctrine/QueryFunction/GetUserFromDatabase.php
+++ b/api/src/User/Infrastructure/Persistence/Doctrine/QueryFunction/GetUserFromDatabase.php
@@ -39,7 +39,7 @@ final class GetUserFromDatabase implements GetUser
 SELECT id, email, first_name AS firstName, last_name AS lastName FROM user
 WHERE id = :id;
 SQL;
-        $parameters = ['id' => $uuid->toString()];
+        $parameters = ['id' => (string) $uuid];
         $types = ['id' => \PDO::PARAM_STR];
 
         $statement = $this->connection->executeQuery($query, $parameters, $types);

--- a/api/src/User/Infrastructure/Persistence/Doctrine/Repository/UserRepository.php
+++ b/api/src/User/Infrastructure/Persistence/Doctrine/Repository/UserRepository.php
@@ -15,8 +15,9 @@ namespace Carcel\User\Infrastructure\Persistence\Doctrine\Repository;
 
 use Carcel\User\Domain\Model\Write\User;
 use Carcel\User\Domain\Repository\UserRepositoryInterface;
-use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ObjectRepository;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * @author Damien Carcel <damien.carcel@gmail.com>
@@ -41,7 +42,7 @@ final class UserRepository implements UserRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function find(string $uuid): ?User
+    public function find(UuidInterface $uuid): ?User
     {
         return $this->getDoctrineRepository()->find($uuid);
     }

--- a/api/src/User/Infrastructure/Persistence/InMemory/QueryFunction/GetUserFromMemory.php
+++ b/api/src/User/Infrastructure/Persistence/InMemory/QueryFunction/GetUserFromMemory.php
@@ -32,7 +32,7 @@ final class GetUserFromMemory implements GetUser
 
     public function __invoke(UuidInterface $uuid): ?User
     {
-        $user = $this->repository->find($uuid->toString());
+        $user = $this->repository->find((string) $uuid);
 
         if (null === $user) {
             return null;

--- a/api/src/User/Infrastructure/Persistence/InMemory/QueryFunction/GetUserFromMemory.php
+++ b/api/src/User/Infrastructure/Persistence/InMemory/QueryFunction/GetUserFromMemory.php
@@ -32,7 +32,7 @@ final class GetUserFromMemory implements GetUser
 
     public function __invoke(UuidInterface $uuid): ?User
     {
-        $user = $this->repository->find((string) $uuid);
+        $user = $this->repository->find($uuid);
 
         if (null === $user) {
             return null;

--- a/api/src/User/Infrastructure/Persistence/InMemory/Repository/UserRepository.php
+++ b/api/src/User/Infrastructure/Persistence/InMemory/Repository/UserRepository.php
@@ -15,6 +15,7 @@ namespace Carcel\User\Infrastructure\Persistence\InMemory\Repository;
 
 use Carcel\User\Domain\Model\Write\User;
 use Carcel\User\Domain\Repository\UserRepositoryInterface;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * @author Damien Carcel <damien.carcel@gmail.com>
@@ -42,13 +43,13 @@ final class UserRepository implements UserRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function find(string $uuid): ?User
+    public function find(UuidInterface $uuid): ?User
     {
-        if (!array_key_exists($uuid, $this->users)) {
+        if (!array_key_exists((string) $uuid, $this->users)) {
             return null;
         }
 
-        return $this->users[$uuid];
+        return $this->users[(string) $uuid];
     }
 
     /**

--- a/api/src/User/Infrastructure/Persistence/InMemory/Repository/UserRepository.php
+++ b/api/src/User/Infrastructure/Persistence/InMemory/Repository/UserRepository.php
@@ -56,7 +56,7 @@ final class UserRepository implements UserRepositoryInterface
      */
     public function save(User $user): void
     {
-        $this->users[$user->id()->toString()] = $user;
+        $this->users[(string) $user->id()] = $user;
     }
 
     /**
@@ -64,6 +64,6 @@ final class UserRepository implements UserRepositoryInterface
      */
     public function delete(User $user): void
     {
-        unset($this->users[$user->id()->toString()]);
+        unset($this->users[(string) $user->id()]);
     }
 }

--- a/api/tests/acceptance/Context/CreateUserContext.php
+++ b/api/tests/acceptance/Context/CreateUserContext.php
@@ -18,6 +18,7 @@ use Carcel\Tests\Fixtures\UserFixtures;
 use Carcel\User\Application\Command\CreateUser;
 use Carcel\User\Domain\Model\Write\User;
 use Carcel\User\Domain\Repository\UserRepositoryInterface;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Webmozart\Assert\Assert;
 
@@ -71,7 +72,7 @@ final class CreateUserContext implements Context
         $newUuidList = array_diff($fetchedUsersUuidList, $fixtureUsersUuidList);
         Assert::count($newUuidList, 1);
 
-        $newUser = $this->userRepository->find(array_shift($newUuidList));
+        $newUser = $this->userRepository->find(Uuid::fromString(array_shift($newUuidList)));
         Assert::same((string) $newUser->email(), static::NEW_USER['email']);
         Assert::same((string) $newUser->firstName(), static::NEW_USER['firstName']);
         Assert::same((string) $newUser->lastName(), static::NEW_USER['lastName']);

--- a/api/tests/acceptance/Context/CreateUserContext.php
+++ b/api/tests/acceptance/Context/CreateUserContext.php
@@ -64,7 +64,7 @@ final class CreateUserContext implements Context
         Assert::count($users, 12);
 
         $fetchedUsersUuidList = array_map(function (User $user) {
-            return $user->id()->toString();
+            return (string) $user->id();
         }, $users);
         $fixtureUsersUuidList = array_keys(UserFixtures::USERS_DATA);
 

--- a/api/tests/acceptance/Context/DeleteUserContext.php
+++ b/api/tests/acceptance/Context/DeleteUserContext.php
@@ -50,7 +50,7 @@ final class DeleteUserContext implements Context
     {
         $this->deletedUserIdentifier = array_keys(UserFixtures::USERS_DATA)[0];
 
-        $deleteUser = new DeleteUser(Uuid::fromString($this->deletedUserIdentifier));
+        $deleteUser = new DeleteUser($this->deletedUserIdentifier);
         $this->bus->dispatch($deleteUser);
     }
 
@@ -60,7 +60,7 @@ final class DeleteUserContext implements Context
     public function deleteAUserThatDoesNotExist(): void
     {
         try {
-            $this->bus->dispatch(new DeleteUser(Uuid::fromString(UserFixtures::ID_OF_NON_EXISTENT_USER)));
+            $this->bus->dispatch(new DeleteUser(UserFixtures::ID_OF_NON_EXISTENT_USER));
         } catch (\Exception $exception) {
             $this->caughtException = $exception;
         }
@@ -71,7 +71,7 @@ final class DeleteUserContext implements Context
      */
     public function specifiedUserShouldBeRetrieved(): void
     {
-        Assert::null($this->userRepository->find($this->deletedUserIdentifier));
+        Assert::null($this->userRepository->find(Uuid::fromString($this->deletedUserIdentifier)));
     }
 
     /**

--- a/api/tests/acceptance/Context/FixtureContext.php
+++ b/api/tests/acceptance/Context/FixtureContext.php
@@ -15,6 +15,7 @@ namespace Carcel\Tests\Acceptance\Context;
 
 use Behat\Behat\Context\Context;
 use Carcel\Tests\Fixtures\UserFixtures;
+use Carcel\User\Domain\Factory\UserFactory;
 use Carcel\User\Domain\Repository\UserRepositoryInterface;
 
 /**
@@ -22,11 +23,13 @@ use Carcel\User\Domain\Repository\UserRepositoryInterface;
  */
 final class FixtureContext implements Context
 {
-    private $userRepository;
+    private $factory;
+    private $repository;
 
-    public function __construct(UserRepositoryInterface $userRepository)
+    public function __construct(UserFactory $factory, UserRepositoryInterface $repository)
     {
-        $this->userRepository = $userRepository;
+        $this->factory = $factory;
+        $this->repository = $repository;
     }
 
     /**
@@ -34,10 +37,17 @@ final class FixtureContext implements Context
      */
     public function loadUsers(): void
     {
-        $users = UserFixtures::instantiateUserEntities();
+        $userIds = array_keys(UserFixtures::USERS_DATA);
 
-        foreach ($users as $user) {
-            $this->userRepository->save($user);
+        foreach ($userIds as $id) {
+            $user = $this->factory->create(
+                $id,
+                UserFixtures::USERS_DATA[$id]['firstName'],
+                UserFixtures::USERS_DATA[$id]['lastName'],
+                UserFixtures::USERS_DATA[$id]['email'],
+            );
+
+            $this->repository->save($user);
         }
     }
 }

--- a/api/tests/acceptance/Context/GetUserContext.php
+++ b/api/tests/acceptance/Context/GetUserContext.php
@@ -18,7 +18,6 @@ use Carcel\Tests\Fixtures\UserFixtures;
 use Carcel\User\Application\Query\GetUser;
 use Carcel\User\Domain\Exception\UserDoesNotExist;
 use Carcel\User\Domain\Model\Read\User;
-use Ramsey\Uuid\Uuid;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -49,9 +48,8 @@ final class GetUserContext implements Context
     public function askForASpecificUser(): void
     {
         $uuidList = array_keys(UserFixtures::USERS_DATA);
-        $uuid = Uuid::fromString($uuidList[0]);
 
-        $this->userEnvelope = $this->bus->dispatch(new GetUser($uuid));
+        $this->userEnvelope = $this->bus->dispatch(new GetUser($uuidList[0]));
     }
 
     /**
@@ -59,10 +57,8 @@ final class GetUserContext implements Context
      */
     public function askForAUserThatDoesNotExist(): void
     {
-        $uuid = Uuid::fromString(UserFixtures::ID_OF_NON_EXISTENT_USER);
-
         try {
-            $this->userEnvelope = $this->bus->dispatch(new GetUser($uuid));
+            $this->userEnvelope = $this->bus->dispatch(new GetUser(UserFixtures::ID_OF_NON_EXISTENT_USER));
         } catch (\Exception $exception) {
             $this->caughtException = $exception;
         }

--- a/api/tests/acceptance/Context/UpdateUserContext.php
+++ b/api/tests/acceptance/Context/UpdateUserContext.php
@@ -51,7 +51,7 @@ final class UpdateUserContext implements Context
         $this->updatedUserIdentifier = array_keys(UserFixtures::USERS_DATA)[0];
 
         $changeUserName = new UpdateUserData(
-            Uuid::fromString($this->updatedUserIdentifier),
+            $this->updatedUserIdentifier,
             'new.ironman@avengers.org',
             'Peter',
             'Parker'
@@ -67,7 +67,7 @@ final class UpdateUserContext implements Context
         $this->updatedUserIdentifier = array_keys(UserFixtures::USERS_DATA)[0];
 
         $changeUserName = new UpdateUserData(
-            Uuid::fromString($this->updatedUserIdentifier),
+            $this->updatedUserIdentifier,
             'new.ironman@avengers.org',
             UserFixtures::USERS_DATA[$this->updatedUserIdentifier]['firstName'],
             UserFixtures::USERS_DATA[$this->updatedUserIdentifier]['lastName']
@@ -83,7 +83,7 @@ final class UpdateUserContext implements Context
         $this->updatedUserIdentifier = array_keys(UserFixtures::USERS_DATA)[0];
 
         $changeUserName = new UpdateUserData(
-            Uuid::fromString($this->updatedUserIdentifier),
+            $this->updatedUserIdentifier,
             UserFixtures::USERS_DATA[$this->updatedUserIdentifier]['email'],
             'Peter',
             UserFixtures::USERS_DATA[$this->updatedUserIdentifier]['lastName']
@@ -99,7 +99,7 @@ final class UpdateUserContext implements Context
         $this->updatedUserIdentifier = array_keys(UserFixtures::USERS_DATA)[0];
 
         $changeUserName = new UpdateUserData(
-            Uuid::fromString($this->updatedUserIdentifier),
+            $this->updatedUserIdentifier,
             UserFixtures::USERS_DATA[$this->updatedUserIdentifier]['email'],
             UserFixtures::USERS_DATA[$this->updatedUserIdentifier]['firstName'],
             'Parker'
@@ -114,7 +114,7 @@ final class UpdateUserContext implements Context
     {
         try {
             $changeUserName = new UpdateUserData(
-                Uuid::fromString(Uuid::fromString(UserFixtures::ID_OF_NON_EXISTENT_USER)),
+                UserFixtures::ID_OF_NON_EXISTENT_USER,
                 'peter.parker@avengers.org',
                 'Peter',
                 'Parker'
@@ -130,7 +130,7 @@ final class UpdateUserContext implements Context
      */
     public function userHasNewData(): void
     {
-        $updatedUser = $this->userRepository->find($this->updatedUserIdentifier);
+        $updatedUser = $this->userRepository->find(Uuid::fromString($this->updatedUserIdentifier));
 
         Assert::same((string) $updatedUser->email(), 'new.ironman@avengers.org');
         Assert::same((string) $updatedUser->firstName(), 'Peter');
@@ -142,7 +142,7 @@ final class UpdateUserContext implements Context
      */
     public function userHasNewEmail(): void
     {
-        $updatedUser = $this->userRepository->find($this->updatedUserIdentifier);
+        $updatedUser = $this->userRepository->find(Uuid::fromString($this->updatedUserIdentifier));
 
         Assert::same(
             (string) $updatedUser->email(),
@@ -163,7 +163,7 @@ final class UpdateUserContext implements Context
      */
     public function userHasANewFirstName(): void
     {
-        $updatedUser = $this->userRepository->find($this->updatedUserIdentifier);
+        $updatedUser = $this->userRepository->find(Uuid::fromString($this->updatedUserIdentifier));
 
         Assert::same(
             (string) $updatedUser->email(),
@@ -184,7 +184,7 @@ final class UpdateUserContext implements Context
      */
     public function userHasANewLastName(): void
     {
-        $updatedUser = $this->userRepository->find($this->updatedUserIdentifier);
+        $updatedUser = $this->userRepository->find(Uuid::fromString($this->updatedUserIdentifier));
 
         Assert::same(
             (string) $updatedUser->email(),

--- a/api/tests/fixtures/UserFixtures.php
+++ b/api/tests/fixtures/UserFixtures.php
@@ -140,7 +140,9 @@ final class UserFixtures extends Fixture
     public static function getNormalizedUsers(): array
     {
         $normalizedUsers = [];
-        foreach (UserFixtures::USERS_DATA as $userId => $userData) {
+
+        $userIds = array_keys(UserFixtures::USERS_DATA);
+        foreach ($userIds as $userId) {
             $normalizedUsers[] = static::getNormalizedUser($userId);
         }
 

--- a/api/tests/fixtures/UserFixtures.php
+++ b/api/tests/fixtures/UserFixtures.php
@@ -13,13 +13,9 @@ declare(strict_types=1);
 
 namespace Carcel\Tests\Fixtures;
 
-use Carcel\User\Domain\Model\Write\Email;
-use Carcel\User\Domain\Model\Write\FirstName;
-use Carcel\User\Domain\Model\Write\LastName;
-use Carcel\User\Domain\Model\Write\User;
+use Carcel\User\Domain\Factory\UserFactory;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\Persistence\ObjectManager;
-use Ramsey\Uuid\Uuid;
 
 /**
  * @author Damien Carcel <damien.carcel@gmail.com>
@@ -98,43 +94,26 @@ final class UserFixtures extends Fixture
      */
     public function load(ObjectManager $objectManager): void
     {
+        $factory = new UserFactory();
+
         if (empty($this->userIdsToLoad)) {
-            $users = static::instantiateUserEntities();
-        } else {
-            $users = array_map(function (string $userId) {
-                return static::instantiateUserEntity($userId);
-            }, $this->userIdsToLoad);
+            $this->userIdsToLoad = array_keys(static::USERS_DATA);
         }
+
+        $users = array_map(function (string $userId) use ($factory) {
+            return $factory->create(
+                $userId,
+                static::USERS_DATA[$userId]['firstName'],
+                static::USERS_DATA[$userId]['lastName'],
+                static::USERS_DATA[$userId]['email'],
+            );
+        }, $this->userIdsToLoad);
 
         foreach ($users as $user) {
             $objectManager->persist($user);
         }
 
         $objectManager->flush();
-    }
-
-    /**
-     * @return User[]
-     */
-    public static function instantiateUserEntities(): array
-    {
-        $users = [];
-        foreach (static::USERS_DATA as $userId => $userData) {
-            $users[] = static::createUser(array_merge(
-                ['id' => $userId],
-                $userData
-            ));
-        }
-
-        return $users;
-    }
-
-    public static function instantiateUserEntity(string $userId): User
-    {
-        return static::createUser(array_merge(
-            ['id' => $userId],
-            static::USERS_DATA[$userId]
-        ));
     }
 
     public static function getNormalizedUsers(): array
@@ -157,15 +136,5 @@ final class UserFixtures extends Fixture
             'firstName' => static::USERS_DATA[$userId]['firstName'],
             'lastName' => static::USERS_DATA[$userId]['lastName'],
         ];
-    }
-
-    private static function createUser(array $userData): User
-    {
-        return new User(
-            Uuid::fromString($userData['id']),
-            Email::fromString($userData['email']),
-            FirstName::fromString($userData['firstName']),
-            LastName::fromString($userData['lastName']),
-        );
     }
 }

--- a/api/tests/integration/User/Infrastructure/Persistence/Doctrine/Repository/UserRepositoryTest.php
+++ b/api/tests/integration/User/Infrastructure/Persistence/Doctrine/Repository/UserRepositoryTest.php
@@ -16,6 +16,7 @@ namespace Carcel\Tests\Integration\User\Infrastructure\Persistence\Doctrine\Repo
 use Carcel\Tests\Fixtures\UserFixtures;
 use Carcel\Tests\Integration\TestCase;
 use Carcel\User\Domain\Repository\UserRepositoryInterface;
+use Ramsey\Uuid\Uuid;
 
 /**
  * @author Damien Carcel <damien.carcel@gmail.com>
@@ -53,7 +54,7 @@ final class UserRepositoryTest extends TestCase
     {
         static::assertEquals(
             UserFixtures::instantiateUserEntity($this->userIDs[0]),
-            $this->repository()->find($this->userIDs[0])
+            $this->repository()->find(Uuid::fromString($this->userIDs[0]))
         );
     }
 
@@ -65,16 +66,16 @@ final class UserRepositoryTest extends TestCase
         $this->repository()->save($user);
 
         static::assertCount(3, $this->repository()->findAll());
-        static::assertSame($user, $this->repository()->find('1605a575-77e5-4427-bbdb-2ebcb8cc8033'));
+        static::assertSame($user, $this->repository()->find(Uuid::fromString('1605a575-77e5-4427-bbdb-2ebcb8cc8033')));
     }
 
     /** @test */
     public function itDeletesAUser(): void
     {
-        $this->repository()->delete($this->repository()->find($this->userIDs[0]));
+        $this->repository()->delete($this->repository()->find(Uuid::fromString($this->userIDs[0])));
 
         static::assertCount(1, $this->repository()->findAll());
-        static::assertNull($this->repository()->find($this->userIDs[0]));
+        static::assertNull($this->repository()->find(Uuid::fromString($this->userIDs[0])));
     }
 
     private function repository(): UserRepositoryInterface

--- a/api/tests/integration/User/Infrastructure/Persistence/Doctrine/Repository/UserRepositoryTest.php
+++ b/api/tests/integration/User/Infrastructure/Persistence/Doctrine/Repository/UserRepositoryTest.php
@@ -15,6 +15,8 @@ namespace Carcel\Tests\Integration\User\Infrastructure\Persistence\Doctrine\Repo
 
 use Carcel\Tests\Fixtures\UserFixtures;
 use Carcel\Tests\Integration\TestCase;
+use Carcel\User\Domain\Factory\UserFactory;
+use Carcel\User\Domain\Model\Write\User;
 use Carcel\User\Domain\Repository\UserRepositoryInterface;
 use Ramsey\Uuid\Uuid;
 
@@ -44,8 +46,8 @@ final class UserRepositoryTest extends TestCase
 
         static::assertCount(2, $users);
         static::assertEquals([
-            UserFixtures::instantiateUserEntity($this->userIDs[0]),
-            UserFixtures::instantiateUserEntity($this->userIDs[1]),
+            $this->instantiateUser($this->userIDs[0]),
+            $this->instantiateUser($this->userIDs[1]),
         ], $users);
     }
 
@@ -53,7 +55,7 @@ final class UserRepositoryTest extends TestCase
     public function itFindAUserFromItsId(): void
     {
         static::assertEquals(
-            UserFixtures::instantiateUserEntity($this->userIDs[0]),
+            $this->instantiateUser($this->userIDs[0]),
             $this->repository()->find(Uuid::fromString($this->userIDs[0]))
         );
     }
@@ -61,7 +63,7 @@ final class UserRepositoryTest extends TestCase
     /** @test */
     public function itSavesAUser(): void
     {
-        $user = UserFixtures::instantiateUserEntity('1605a575-77e5-4427-bbdb-2ebcb8cc8033');
+        $user = $this->instantiateUser('1605a575-77e5-4427-bbdb-2ebcb8cc8033');
 
         $this->repository()->save($user);
 
@@ -81,5 +83,17 @@ final class UserRepositoryTest extends TestCase
     private function repository(): UserRepositoryInterface
     {
         return $this->container()->get(UserRepositoryInterface::class);
+    }
+
+    private function instantiateUser(string $userId): User
+    {
+        $factory = new UserFactory();
+
+        return $factory->create(
+            $userId,
+            UserFixtures::USERS_DATA[$userId]['firstName'],
+            UserFixtures::USERS_DATA[$userId]['lastName'],
+            UserFixtures::USERS_DATA[$userId]['email'],
+        );
     }
 }

--- a/api/tests/unit/User/Application/Command/CreateUserTest.php
+++ b/api/tests/unit/User/Application/Command/CreateUserTest.php
@@ -22,14 +22,6 @@ use PHPUnit\Framework\TestCase;
 final class CreateUserTest extends TestCase
 {
     /** @test */
-    public function itIsACreateUserCommand(): void
-    {
-        $createUser = $this->instantiateValidCreateUser();
-
-        static::assertInstanceOf(CreateUser::class, $createUser);
-    }
-
-    /** @test */
     public function itReturnsTheUsersEmail(): void
     {
         $createUser = $this->instantiateValidCreateUser();

--- a/api/tests/unit/User/Application/Command/CreateUserTest.php
+++ b/api/tests/unit/User/Application/Command/CreateUserTest.php
@@ -30,7 +30,7 @@ final class CreateUserTest extends TestCase
     }
 
     /** @test */
-    public function itReturnsTheUsersFirstname(): void
+    public function itReturnsTheUsersFirstName(): void
     {
         $createUser = $this->instantiateValidCreateUser();
 
@@ -38,7 +38,7 @@ final class CreateUserTest extends TestCase
     }
 
     /** @test */
-    public function itReturnsTheUsersLastname(): void
+    public function itReturnsTheUsersLastName(): void
     {
         $createUser = $this->instantiateValidCreateUser();
 

--- a/api/tests/unit/User/Application/Command/DeleteUserTest.php
+++ b/api/tests/unit/User/Application/Command/DeleteUserTest.php
@@ -15,7 +15,6 @@ namespace Carcel\Tests\Unit\User\Application\Command;
 
 use Carcel\User\Application\Command\DeleteUser;
 use PHPUnit\Framework\TestCase;
-use Ramsey\Uuid\Uuid;
 
 /**
  * @author Damien Carcel <damien.carcel@gmail.com>
@@ -27,11 +26,11 @@ final class DeleteUserTest extends TestCase
     {
         $deleteUser = $this->instantiateValidDeleteUser();
 
-        static::assertEquals(Uuid::fromString('df25ad55-126d-4160-89ff-a974725cb183'), $deleteUser->identifier());
+        static::assertEquals('df25ad55-126d-4160-89ff-a974725cb183', $deleteUser->identifier());
     }
 
     private function instantiateValidDeleteUser(): DeleteUser
     {
-        return new DeleteUser(Uuid::fromString('df25ad55-126d-4160-89ff-a974725cb183'));
+        return new DeleteUser('df25ad55-126d-4160-89ff-a974725cb183');
     }
 }

--- a/api/tests/unit/User/Application/Command/DeleteUserTest.php
+++ b/api/tests/unit/User/Application/Command/DeleteUserTest.php
@@ -23,14 +23,6 @@ use Ramsey\Uuid\Uuid;
 final class DeleteUserTest extends TestCase
 {
     /** @test */
-    public function itIsACreateUserCommand(): void
-    {
-        $deleteUser = $this->instantiateValidDeleteUser();
-
-        static::assertInstanceOf(DeleteUser::class, $deleteUser);
-    }
-
-    /** @test */
     public function itReturnsTheUsersEmail(): void
     {
         $deleteUser = $this->instantiateValidDeleteUser();

--- a/api/tests/unit/User/Application/Command/UpdateUserDataTest.php
+++ b/api/tests/unit/User/Application/Command/UpdateUserDataTest.php
@@ -15,7 +15,6 @@ namespace Carcel\Tests\Unit\User\Application\Command;
 
 use Carcel\User\Application\Command\UpdateUserData;
 use PHPUnit\Framework\TestCase;
-use Ramsey\Uuid\Uuid;
 
 /**
  * @author Damien Carcel <damien.carcel@gmail.com>
@@ -27,11 +26,11 @@ final class UpdateUserDataTest extends TestCase
     {
         $createUser = $this->instantiateValidChangeUserName();
 
-        static::assertEquals(Uuid::fromString('3d8fbf56-3a34-465b-9776-c3b69c510eef'), $createUser->identifier());
+        static::assertEquals('3d8fbf56-3a34-465b-9776-c3b69c510eef', $createUser->identifier());
     }
 
     /** @test */
-    public function itReturnsTheUsersRmail(): void
+    public function itReturnsTheUsersEmail(): void
     {
         $createUser = $this->instantiateValidChangeUserName();
 
@@ -57,7 +56,7 @@ final class UpdateUserDataTest extends TestCase
     private function instantiateValidChangeUserName(): UpdateUserData
     {
         return new UpdateUserData(
-            Uuid::fromString('3d8fbf56-3a34-465b-9776-c3b69c510eef'),
+            '3d8fbf56-3a34-465b-9776-c3b69c510eef',
             'batman@justiceleague.org',
             'Bruce',
             'Wayne'

--- a/api/tests/unit/User/Application/Command/UpdateUserDataTest.php
+++ b/api/tests/unit/User/Application/Command/UpdateUserDataTest.php
@@ -23,14 +23,6 @@ use Ramsey\Uuid\Uuid;
 final class UpdateUserDataTest extends TestCase
 {
     /** @test */
-    public function itIsAChangeUserNameCommand(): void
-    {
-        $createUser = $this->instantiateValidChangeUserName();
-
-        static::assertInstanceOf(UpdateUserData::class, $createUser);
-    }
-
-    /** @test */
     public function itReturnsTheUsersId(): void
     {
         $createUser = $this->instantiateValidChangeUserName();

--- a/api/tests/unit/User/Application/Query/GetUserListTest.php
+++ b/api/tests/unit/User/Application/Query/GetUserListTest.php
@@ -22,14 +22,6 @@ use PHPUnit\Framework\TestCase;
 final class GetUserListTest extends TestCase
 {
     /** @test */
-    public function itIsAGetUserListQuery(): void
-    {
-        $getUserList = $this->instantiateValidGetUserList();
-
-        static::assertInstanceOf(GetUserList::class, $getUserList);
-    }
-
-    /** @test */
     public function itReturnsTheNumberOfUsersTheListWillContain(): void
     {
         $getUserList = $this->instantiateValidGetUserList();
@@ -41,6 +33,7 @@ final class GetUserListTest extends TestCase
     public function itReturnsTheUserPage(): void
     {
         $getUserList = $this->instantiateValidGetUserList();
+
         static::assertSame(1, $getUserList->userPage());
     }
 

--- a/api/tests/unit/User/Application/Query/GetUserTest.php
+++ b/api/tests/unit/User/Application/Query/GetUserTest.php
@@ -25,17 +25,10 @@ final class GetUserTest extends TestCase
     private const USER_IDENTIFIER = '02432f0b-c33e-4d71-8ba9-a5e3267a45d5';
 
     /** @test */
-    public function itIsAGetUserQuery(): void
-    {
-        $getUser = $this->instantiateValidGetUser();
-
-        static::assertInstanceOf(GetUser::class, $getUser);
-    }
-
-    /** @test */
     public function itReturnsTheUserIdentifier(): void
     {
         $getUser = $this->instantiateValidGetUser();
+
         static::assertSame(static::USER_IDENTIFIER, $getUser->identifier()->toString());
     }
 

--- a/api/tests/unit/User/Application/Query/GetUserTest.php
+++ b/api/tests/unit/User/Application/Query/GetUserTest.php
@@ -29,7 +29,7 @@ final class GetUserTest extends TestCase
     {
         $getUser = $this->instantiateValidGetUser();
 
-        static::assertSame(static::USER_IDENTIFIER, $getUser->identifier()->toString());
+        static::assertSame(static::USER_IDENTIFIER, (string) $getUser->identifier());
     }
 
     private function instantiateValidGetUser(): GetUser

--- a/api/tests/unit/User/Application/Query/GetUserTest.php
+++ b/api/tests/unit/User/Application/Query/GetUserTest.php
@@ -15,7 +15,6 @@ namespace Carcel\Tests\Unit\User\Application\Query;
 
 use Carcel\User\Application\Query\GetUser;
 use PHPUnit\Framework\TestCase;
-use Ramsey\Uuid\Uuid;
 
 /**
  * @author Damien Carcel <damien.carcel@gmail.com>
@@ -29,11 +28,11 @@ final class GetUserTest extends TestCase
     {
         $getUser = $this->instantiateValidGetUser();
 
-        static::assertSame(static::USER_IDENTIFIER, (string) $getUser->identifier());
+        static::assertSame(static::USER_IDENTIFIER, $getUser->identifier());
     }
 
     private function instantiateValidGetUser(): GetUser
     {
-        return new GetUser(Uuid::fromString(static::USER_IDENTIFIER));
+        return new GetUser(static::USER_IDENTIFIER);
     }
 }

--- a/api/tests/unit/User/Domain/Exception/UserDoesNotExistTest.php
+++ b/api/tests/unit/User/Domain/Exception/UserDoesNotExistTest.php
@@ -16,7 +16,6 @@ namespace Carcel\Tests\Unit\User\Domain\Exception;
 use Carcel\Tests\Fixtures\UserFixtures;
 use Carcel\User\Domain\Exception\UserDoesNotExist;
 use PHPUnit\Framework\TestCase;
-use Ramsey\Uuid\Uuid;
 
 /**
  * @author Damien Carcel <damien.carcel@gmail.com>
@@ -36,6 +35,6 @@ final class UserDoesNotExistTest extends TestCase
 
     private function instantiateUserDoesNotExist(): UserDoesNotExist
     {
-        return UserDoesNotExist::fromUuid(Uuid::fromString(UserFixtures::ID_OF_NON_EXISTENT_USER));
+        return UserDoesNotExist::fromUuid(UserFixtures::ID_OF_NON_EXISTENT_USER);
     }
 }

--- a/api/tests/unit/User/Domain/Exception/UserDoesNotExistTest.php
+++ b/api/tests/unit/User/Domain/Exception/UserDoesNotExistTest.php
@@ -24,16 +24,10 @@ use Ramsey\Uuid\Uuid;
 final class UserDoesNotExistTest extends TestCase
 {
     /** @test */
-    public function itIsAUserDoesNotExistException(): void
-    {
-        $exception = $this->instantiateUserDoesNotExist();
-        static::assertInstanceOf(UserDoesNotExist::class, $exception);
-    }
-
-    /** @test */
     public function itReturnsAMessage(): void
     {
         $exception = $this->instantiateUserDoesNotExist();
+
         static::assertSame(
             sprintf('There is no user with identifier "%s"', UserFixtures::ID_OF_NON_EXISTENT_USER),
             $exception->getMessage()

--- a/api/tests/unit/User/Domain/Factory/UserFactoryTest.php
+++ b/api/tests/unit/User/Domain/Factory/UserFactoryTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of app-skeleton.
+ *
+ * Copyright (c) 2019 Damien Carcel <damien.carcel@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Carcel\Tests\Unit\User\Domain\Factory;
+
+use Carcel\Tests\Fixtures\UserFixtures;
+use Carcel\Tests\Integration\TestCase;
+use Carcel\User\Domain\Factory\UserFactory;
+use PHPUnit\Framework\Assert;
+
+/**
+ * @author Damien Carcel <damien.carcel@gmail.com>
+ */
+final class UserFactoryTest extends TestCase
+{
+    /** @test */
+    public function itInstantiateAUser(): void
+    {
+        $userId = '02432f0b-c33e-4d71-8ba9-a5e3267a45d5';
+
+        $factory = $this->instantiateUserFactory();
+        $user = $factory->create(
+            $userId,
+            UserFixtures::USERS_DATA[$userId]['firstName'],
+            UserFixtures::USERS_DATA[$userId]['lastName'],
+            UserFixtures::USERS_DATA[$userId]['email'],
+        );
+
+        Assert::assertSame('Tony', (string) $user->firstName());
+        Assert::assertSame('Stark', (string) $user->lastName());
+        Assert::assertSame('ironman@avengers.org', (string) $user->email());
+    }
+
+    private function instantiateUserFactory(): UserFactory
+    {
+        return new UserFactory();
+    }
+}

--- a/api/tests/unit/User/Domain/Model/Read/UserListTest.php
+++ b/api/tests/unit/User/Domain/Model/Read/UserListTest.php
@@ -29,6 +29,8 @@ final class UserListTest extends TestCase
      */
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->usersData = UserFixtures::getNormalizedUsers();
     }
 

--- a/api/tests/unit/User/Domain/Model/Read/UserListTest.php
+++ b/api/tests/unit/User/Domain/Model/Read/UserListTest.php
@@ -33,12 +33,6 @@ final class UserListTest extends TestCase
     }
 
     /** @test */
-    public function itIsAListOfUserReadModels(): void
-    {
-        static::assertInstanceOf(UserList::class, $this->instantiateUserList());
-    }
-
-    /** @test */
     public function itCanCreateAnEmptyUserList(): void
     {
         static::assertInstanceOf(UserList::class, new UserList([]));

--- a/api/tests/unit/User/Domain/Model/Read/UserTest.php
+++ b/api/tests/unit/User/Domain/Model/Read/UserTest.php
@@ -33,12 +33,6 @@ final class UserTest extends TestCase
     }
 
     /** @test */
-    public function itIsAUserReadModel(): void
-    {
-        static::assertInstanceOf(User::class, $this->instantiateValidUserReadModel());
-    }
-
-    /** @test */
     public function aUserReadModelCanNormalizeItself(): void
     {
         $user = $this->instantiateValidUserReadModel();

--- a/api/tests/unit/User/Domain/Model/Write/EmailTest.php
+++ b/api/tests/unit/User/Domain/Model/Write/EmailTest.php
@@ -22,12 +22,6 @@ use PHPUnit\Framework\TestCase;
 final class EmailTest extends TestCase
 {
     /** @test */
-    public function itInstantiateAEmail(): void
-    {
-        static::assertInstanceOf(Email::class, Email::fromString('ironman@avengers.org'));
-    }
-
-    /** @test */
     public function itReturnsTheEmail(): void
     {
         static::assertSame(

--- a/api/tests/unit/User/Domain/Model/Write/FirstNameTest.php
+++ b/api/tests/unit/User/Domain/Model/Write/FirstNameTest.php
@@ -22,12 +22,6 @@ use PHPUnit\Framework\TestCase;
 final class FirstNameTest extends TestCase
 {
     /** @test */
-    public function itInstantiateAFirstName(): void
-    {
-        static::assertInstanceOf(FirstName::class, FirstName::fromString('Tony'));
-    }
-
-    /** @test */
     public function itReturnsTheFirstName(): void
     {
         static::assertSame(

--- a/api/tests/unit/User/Domain/Model/Write/LastNameTest.php
+++ b/api/tests/unit/User/Domain/Model/Write/LastNameTest.php
@@ -22,12 +22,6 @@ use PHPUnit\Framework\TestCase;
 final class LastNameTest extends TestCase
 {
     /** @test */
-    public function itInstantiateALastName(): void
-    {
-        static::assertInstanceOf(LastName::class, LastName::fromString('Tony'));
-    }
-
-    /** @test */
     public function itReturnsTheLastName(): void
     {
         static::assertSame(

--- a/api/tests/unit/User/Domain/Model/Write/UserTest.php
+++ b/api/tests/unit/User/Domain/Model/Write/UserTest.php
@@ -26,12 +26,6 @@ use PHPUnit\Framework\TestCase;
 final class UserTest extends TestCase
 {
     /** @test */
-    public function itIsAUser(): void
-    {
-        static::assertInstanceOf(User::class, $this->instantiateTonyStark());
-    }
-
-    /** @test */
     public function itHasAnIdentifier(): void
     {
         $user = $this->instantiateTonyStark();

--- a/api/tests/unit/User/Domain/Model/Write/UserTest.php
+++ b/api/tests/unit/User/Domain/Model/Write/UserTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Carcel\Tests\Unit\User\Domain\Model\Write;
 
 use Carcel\Tests\Fixtures\UserFixtures;
+use Carcel\User\Domain\Factory\UserFactory;
 use Carcel\User\Domain\Model\Write\Email;
 use Carcel\User\Domain\Model\Write\FirstName;
 use Carcel\User\Domain\Model\Write\LastName;
@@ -66,9 +67,9 @@ final class UserTest extends TestCase
         $user = $this->instantiateTonyStark();
 
         $user->update(
-            Email::fromString('new.ironman@advengers.org'),
             FirstName::fromString('Peter'),
-            LastName::fromString('Parker')
+            LastName::fromString('Parker'),
+            Email::fromString('new.ironman@advengers.org'),
         );
 
         static::assertSame('new.ironman@advengers.org', (string) $user->email());
@@ -78,6 +79,13 @@ final class UserTest extends TestCase
 
     private function instantiateTonyStark(): User
     {
-        return UserFixtures::instantiateUserEntity('02432f0b-c33e-4d71-8ba9-a5e3267a45d5');
+        $factory = new UserFactory();
+
+        return $factory->create(
+            '02432f0b-c33e-4d71-8ba9-a5e3267a45d5',
+            UserFixtures::USERS_DATA['02432f0b-c33e-4d71-8ba9-a5e3267a45d5']['firstName'],
+            UserFixtures::USERS_DATA['02432f0b-c33e-4d71-8ba9-a5e3267a45d5']['lastName'],
+            UserFixtures::USERS_DATA['02432f0b-c33e-4d71-8ba9-a5e3267a45d5']['email'],
+        );
     }
 }

--- a/api/tests/unit/User/Infrastructure/Persistence/InMemory/QueryFunction/GetUserFromMemoryTest.php
+++ b/api/tests/unit/User/Infrastructure/Persistence/InMemory/QueryFunction/GetUserFromMemoryTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Carcel\Tests\Unit\User\Infrastructure\Persistence\InMemory\QueryFunction;
 
 use Carcel\Tests\Fixtures\UserFixtures;
+use Carcel\User\Domain\Factory\UserFactory;
 use Carcel\User\Domain\Model\Read\User;
 use Carcel\User\Domain\Repository\UserRepositoryInterface;
 use Carcel\User\Infrastructure\Persistence\InMemory\QueryFunction\GetUserFromMemory;
@@ -62,10 +63,19 @@ final class GetUserFromMemoryTest extends TestCase
 
     private function instantiateInMemoryUserRepository(): UserRepositoryInterface
     {
+        $factory = new UserFactory();
         $repository = new UserRepository();
 
-        $users = UserFixtures::instantiateUserEntities();
-        foreach ($users as $user) {
+        $userIds = array_keys(UserFixtures::USERS_DATA);
+
+        foreach ($userIds as $id) {
+            $user = $factory->create(
+                $id,
+                UserFixtures::USERS_DATA[$id]['firstName'],
+                UserFixtures::USERS_DATA[$id]['lastName'],
+                UserFixtures::USERS_DATA[$id]['email'],
+            );
+
             $repository->save($user);
         }
 

--- a/api/tests/unit/User/Infrastructure/Persistence/InMemory/QueryFunction/GetUserFromMemoryTest.php
+++ b/api/tests/unit/User/Infrastructure/Persistence/InMemory/QueryFunction/GetUserFromMemoryTest.php
@@ -34,6 +34,8 @@ final class GetUserFromMemoryTest extends TestCase
      */
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->getUserFromMemory = new GetUserFromMemory($this->instantiateInMemoryUserRepository());
     }
 

--- a/api/tests/unit/User/Infrastructure/Persistence/InMemory/QueryFunction/GetUserListFromMemoryTest.php
+++ b/api/tests/unit/User/Infrastructure/Persistence/InMemory/QueryFunction/GetUserListFromMemoryTest.php
@@ -37,12 +37,6 @@ final class GetUserListFromMemoryTest extends TestCase
     }
 
     /** @test */
-    public function itIsAGetUserListQuery(): void
-    {
-        static::assertInstanceOf(GetUserListFromMemory::class, $this->getUserListFromMemory);
-    }
-
-    /** @test */
     public function itGetsAListOfUsers(): void
     {
         $users = ($this->getUserListFromMemory)(10, 1);

--- a/api/tests/unit/User/Infrastructure/Persistence/InMemory/QueryFunction/GetUserListFromMemoryTest.php
+++ b/api/tests/unit/User/Infrastructure/Persistence/InMemory/QueryFunction/GetUserListFromMemoryTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Carcel\Tests\Unit\User\Infrastructure\Persistence\InMemory\QueryFunction;
 
 use Carcel\Tests\Fixtures\UserFixtures;
+use Carcel\User\Domain\Factory\UserFactory;
 use Carcel\User\Domain\Model\Read\UserList;
 use Carcel\User\Domain\Repository\UserRepositoryInterface;
 use Carcel\User\Infrastructure\Persistence\InMemory\QueryFunction\GetUserListFromMemory;
@@ -112,10 +113,19 @@ final class GetUserListFromMemoryTest extends TestCase
 
     private function instantiateInMemoryUserRepository(): UserRepositoryInterface
     {
+        $factory = new UserFactory();
         $repository = new UserRepository();
 
-        $users = UserFixtures::instantiateUserEntities();
-        foreach ($users as $user) {
+        $userIds = array_keys(UserFixtures::USERS_DATA);
+
+        foreach ($userIds as $id) {
+            $user = $factory->create(
+                $id,
+                UserFixtures::USERS_DATA[$id]['firstName'],
+                UserFixtures::USERS_DATA[$id]['lastName'],
+                UserFixtures::USERS_DATA[$id]['email'],
+            );
+
             $repository->save($user);
         }
 

--- a/api/tests/unit/User/Infrastructure/Persistence/InMemory/QueryFunction/GetUserListFromMemoryTest.php
+++ b/api/tests/unit/User/Infrastructure/Persistence/InMemory/QueryFunction/GetUserListFromMemoryTest.php
@@ -33,6 +33,8 @@ final class GetUserListFromMemoryTest extends TestCase
      */
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->getUserListFromMemory = new GetUserListFromMemory($this->instantiateInMemoryUserRepository());
     }
 

--- a/api/tests/unit/User/Infrastructure/Persistence/InMemory/Repository/UserRepositoryTest.php
+++ b/api/tests/unit/User/Infrastructure/Persistence/InMemory/Repository/UserRepositoryTest.php
@@ -35,12 +35,6 @@ final class UserRepositoryTest extends TestCase
     }
 
     /** @test */
-    public function itIsAUserRepository(): void
-    {
-        static::assertInstanceOf(UserRepository::class, $this->instantiateRepository());
-    }
-
-    /** @test */
     public function itFindAllUsers(): void
     {
         $repository = $this->instantiateRepository();

--- a/api/tests/unit/User/Infrastructure/Persistence/InMemory/Repository/UserRepositoryTest.php
+++ b/api/tests/unit/User/Infrastructure/Persistence/InMemory/Repository/UserRepositoryTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Carcel\Tests\Unit\User\Infrastructure\Persistence\InMemory\Repository;
 
 use Carcel\Tests\Fixtures\UserFixtures;
+use Carcel\User\Domain\Factory\UserFactory;
+use Carcel\User\Domain\Model\Write\User;
 use Carcel\User\Infrastructure\Persistence\InMemory\Repository\UserRepository;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
@@ -32,8 +34,8 @@ final class UserRepositoryTest extends TestCase
 
         $this->userIDs = ['02432f0b-c33e-4d71-8ba9-a5e3267a45d5', '08acf31d-2e62-44e9-ba18-fd160ac125ad'];
         $this->users = [
-            UserFixtures::instantiateUserEntity($this->userIDs[0]),
-            UserFixtures::instantiateUserEntity($this->userIDs[1]),
+            $this->instantiateUser($this->userIDs[0]),
+            $this->instantiateUser($this->userIDs[1]),
         ];
     }
 
@@ -56,7 +58,7 @@ final class UserRepositoryTest extends TestCase
     /** @test */
     public function itSavesAUser(): void
     {
-        $user = UserFixtures::instantiateUserEntity('1605a575-77e5-4427-bbdb-2ebcb8cc8033');
+        $user = $this->instantiateUser('1605a575-77e5-4427-bbdb-2ebcb8cc8033');
 
         $repository = $this->instantiateRepository();
         $repository->save($user);
@@ -79,5 +81,17 @@ final class UserRepositoryTest extends TestCase
     private function instantiateRepository(): UserRepository
     {
         return new UserRepository($this->users);
+    }
+
+    private function instantiateUser(string $userId): User
+    {
+        $factory = new UserFactory();
+
+        return $factory->create(
+            $userId,
+            UserFixtures::USERS_DATA[$userId]['firstName'],
+            UserFixtures::USERS_DATA[$userId]['lastName'],
+            UserFixtures::USERS_DATA[$userId]['email'],
+        );
     }
 }

--- a/api/tests/unit/User/Infrastructure/Persistence/InMemory/Repository/UserRepositoryTest.php
+++ b/api/tests/unit/User/Infrastructure/Persistence/InMemory/Repository/UserRepositoryTest.php
@@ -16,6 +16,7 @@ namespace Carcel\Tests\Unit\User\Infrastructure\Persistence\InMemory\Repository;
 use Carcel\Tests\Fixtures\UserFixtures;
 use Carcel\User\Infrastructure\Persistence\InMemory\Repository\UserRepository;
 use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
 
 /**
  * @author Damien Carcel <damien.carcel@gmail.com>
@@ -27,6 +28,8 @@ final class UserRepositoryTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->userIDs = ['02432f0b-c33e-4d71-8ba9-a5e3267a45d5', '08acf31d-2e62-44e9-ba18-fd160ac125ad'];
         $this->users = [
             UserFixtures::instantiateUserEntity($this->userIDs[0]),
@@ -47,7 +50,7 @@ final class UserRepositoryTest extends TestCase
     {
         $repository = $this->instantiateRepository();
 
-        static::assertSame($this->users[0], $repository->find($this->userIDs[0]));
+        static::assertSame($this->users[0], $repository->find(Uuid::fromString($this->userIDs[0])));
     }
 
     /** @test */
@@ -59,7 +62,7 @@ final class UserRepositoryTest extends TestCase
         $repository->save($user);
 
         static::assertCount(3, $repository->findAll());
-        static::assertSame($user, $repository->find('1605a575-77e5-4427-bbdb-2ebcb8cc8033'));
+        static::assertSame($user, $repository->find(Uuid::fromString('1605a575-77e5-4427-bbdb-2ebcb8cc8033')));
     }
 
     /** @test */
@@ -70,7 +73,7 @@ final class UserRepositoryTest extends TestCase
         $repository->delete($this->users[0]);
 
         static::assertCount(1, $repository->findAll());
-        static::assertNull($repository->find($this->userIDs[0]));
+        static::assertNull($repository->find(Uuid::fromString($this->userIDs[0])));
     }
 
     private function instantiateRepository(): UserRepository


### PR DESCRIPTION
## Description

- Refactor the usage of UUIds:
    - use `(string) $uuid` instead of `$uuid->toString()`
    - Create `Uuid` objects in command and query handlers, like every other value objects (DTOs only use raw data)
- Introduce user factories, one for the read model, one for the write model, and use them everywhere

## Definition Of Done

| Q                 | A
| ------------------| ---
| Unit tests        | OK
| Acceptance tests  | OK
| Integration tests | OK
| End to End tests  | -
| Documentation     | -
| Related tickets   | #231

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
