### PR TITLE
Issue 152: Fix error in CI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
                 command: make sniff-code-api
             - run:
                 name: Run static analysis - PHPStan
-                command: make analyse-api LEVEL=1
+                command: make analyse-api
             - run:
                 name: Run coupling detector
                 command: make coupling-api


### PR DESCRIPTION
## Description

PHPStan level analysis was still set to 1.

## Definition Of Done

| Q                 | A
| ------------------| ---
| Unit tests        | -
| Acceptance tests  | -
| Integration tests | -
| End to End tests  | -
| Documentation     | -
| Related tickets   | #152

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
