### PR TITLE
Issue 142: Fix Eslint JUnit output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,16 +114,16 @@ jobs:
                 command: mkdir client/reports
             - run:
                 name: Lint CSS/LESS code
-                command: make stylelint SL_OUT="--custom-formatter 'node_modules/stylelint-junit-formatter' > reports/stylelint.xml"
+                command: make stylelint O="--custom-formatter 'node_modules/stylelint-junit-formatter' > reports/stylelint.xml"
             - run:
                 name: Lint JavaScript/TypeScript code
-                command: make eslint ESL_OUT="-f junit -o reports/eslint.xml"
+                command: make eslint O="--no-fix -f junit > reports/eslint.xml"
             - run:
                 name: Run TS type checking
                 command: make type-check-client
             - run:
                 name: Run client unit tests
-                command: make client-unit-tests JEST_OUT="--ci --reporters=default --reporters=jest-junit"
+                command: make client-unit-tests O="--ci --reporters=default --reporters=jest-junit"
             - run:
                 name: Run client end to end tests with Chrome
                 command: make client-e2e-tests-with-chrome

--- a/Makefile
+++ b/Makefile
@@ -4,19 +4,11 @@ SHELL = bash
 
 DEBUG ?= 0
 L ?= max
+O ?=
 TL ?= 6
 
 PHPMD_OUTPUT=ansi
 PHPMD_RULESETS=cleancode,codesize,controversial,design,naming,unusedcode
-
-ESL_OUT ?=
-JEST_OUT ?=
-SL_OUT ?=
-
-SILENT =
-ifneq (${SL_OUT},)
-SILENT = -s
-endif
 
 # Build Docker images
 
@@ -206,15 +198,11 @@ phpmetrics:
 
 .PHONY: stylelint
 stylelint:
-	cd ${CURDIR}/client && docker-compose run --rm node yarn run ${SILENT} stylelint ${SL_OUT}
+	cd ${CURDIR}/client && docker-compose run --rm node yarn run -s stylelint ${O}
 
 .PHONY: eslint
 eslint:
-	cd ${CURDIR}/client && docker-compose run --rm node yarn run lint ${ESL_OUT}
-
-.PHONY: fix-eslint
-fix-eslint:
-	cd ${CURDIR}/client && docker-compose run --rm node yarn run lint --fix
+	cd ${CURDIR}/client && docker-compose run --rm node yarn run -s lint ${O}
 
 .PHONY: type-check-client
 type-check-client:
@@ -222,7 +210,7 @@ type-check-client:
 
 .PHONY: client-unit-tests
 client-unit-tests:
-	cd ${CURDIR}/client && docker-compose run --rm -e JEST_JUNIT_OUTPUT_DIR="./reports" -e JEST_JUNIT_OUTPUT_NAME="jest.xml" node yarn run test:unit ${JEST_OUT}
+	cd ${CURDIR}/client && docker-compose run --rm -e JEST_JUNIT_OUTPUT_DIR="./reports" -e JEST_JUNIT_OUTPUT_NAME="jest.xml" node yarn run test:unit ${O}
 
 .PHONY: client-e2e-tests-with-chrome
 client-e2e-tests-with-chrome:

--- a/client/nightwatch.config.js
+++ b/client/nightwatch.config.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/camelcase */
+
 module.exports = {
   test_settings: {
     chrome: {

--- a/client/package.json
+++ b/client/package.json
@@ -44,8 +44,8 @@
   },
   "devDependencies": {
     "@types/jest": "^25.2.3",
-    "@typescript-eslint/eslint-plugin": "^3.0.0",
-    "@typescript-eslint/parser": "^3.0.0",
+    "@typescript-eslint/eslint-plugin": "^2.26.0",
+    "@typescript-eslint/parser": "^2.26.0",
     "@vue/cli-plugin-babel": "^4.3.0",
     "@vue/cli-plugin-e2e-nightwatch": "^4.3.0",
     "@vue/cli-plugin-eslint": "^4.3.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1249,41 +1249,40 @@
   dependencies:
     "@types/node" "*"
 
-"@typescript-eslint/eslint-plugin@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.0.0.tgz#02f8ec6b5ce814bda80dfc22463f108bed1f699b"
-  integrity sha512-lcZ0M6jD4cqGccYOERKdMtg+VWpoq3NSnWVxpc/AwAy0zhkUYVioOUZmfNqiNH8/eBNGhCn6HXd6mKIGRgNc1Q==
+"@typescript-eslint/eslint-plugin@^2.26.0":
+  version "2.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz#6f8ce8a46c7dea4a6f1d171d2bb8fbae6dac2be9"
+  integrity sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==
   dependencies:
-    "@typescript-eslint/experimental-utils" "3.0.0"
+    "@typescript-eslint/experimental-utils" "2.34.0"
     functional-red-black-tree "^1.0.1"
     regexpp "^3.0.0"
-    semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.0.0.tgz#1ddf53eeb61ac8eaa9a77072722790ac4f641c03"
-  integrity sha512-BN0vmr9N79M9s2ctITtChRuP1+Dls0x/wlg0RXW1yQ7WJKPurg6X3Xirv61J2sjPif4F8SLsFMs5Nzte0WYoTQ==
+"@typescript-eslint/experimental-utils@2.34.0":
+  version "2.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz#d3524b644cdb40eebceca67f8cf3e4cc9c8f980f"
+  integrity sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "3.0.0"
+    "@typescript-eslint/typescript-estree" "2.34.0"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-3.0.0.tgz#fe9fdf18a1155c02c04220c14506a320cb6c6944"
-  integrity sha512-8RRCA9KLxoFNO0mQlrLZA0reGPd/MsobxZS/yPFj+0/XgMdS8+mO8mF3BDj2ZYQj03rkayhSJtF1HAohQ3iylw==
+"@typescript-eslint/parser@^2.26.0":
+  version "2.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.34.0.tgz#50252630ca319685420e9a39ca05fe185a256bc8"
+  integrity sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==
   dependencies:
     "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "3.0.0"
-    "@typescript-eslint/typescript-estree" "3.0.0"
+    "@typescript-eslint/experimental-utils" "2.34.0"
+    "@typescript-eslint/typescript-estree" "2.34.0"
     eslint-visitor-keys "^1.1.0"
 
-"@typescript-eslint/typescript-estree@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-3.0.0.tgz#fa40e1b76ccff880130be054d9c398e96004bf42"
-  integrity sha512-nevQvHyNghsfLrrByzVIH4ZG3NROgJ8LZlfh3ddwPPH4CH7W4GAiSx5qu+xHuX5pWsq6q/eqMc1io840ZhAnUg==
+"@typescript-eslint/typescript-estree@2.34.0":
+  version "2.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz#14aeb6353b39ef0732cc7f1b8285294937cf37d5"
+  integrity sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==
   dependencies:
     debug "^4.1.1"
     eslint-visitor-keys "^1.1.0"


### PR DESCRIPTION
## Description

Vue.js eslint CLI plugin fix by default. Output can only be visible with `--no-fix`, and `-o` eslint option doesn't work, so output have to be redirected to a file.

`typescript-eslint` plugins `v3` are not working properly for now (error message about TypeScript version), so they are reverted to `v2.26`.

## Related ticket

Relates to #142 